### PR TITLE
fix: Add PDFJS worker

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,4 +4,12 @@ const configs = [
   require('./config/webpack.config.cozy-home.js')
 ]
 
+const extraConfig = {
+  resolve: {
+    alias: {
+      'react-pdf$': 'react-pdf/dist/esm/entry.webpack'
+    }
+  }
+}
+configs.push(extraConfig)
 module.exports = configs


### PR DESCRIPTION
We didn’t manage well the cozy UI’ upgrade to 83 here. We forgot to add the new pdfjs entry point. The result was that pdf were not displayed at all.  