### PR TITLE
feat: Adapt search placeholder if assistant is disabled

### DIFF
--- a/src/assistant/AssistantWrapperMobile.jsx
+++ b/src/assistant/AssistantWrapperMobile.jsx
@@ -25,6 +25,8 @@ export const AssistantWrapperMobile = () => {
   const { t } = useI18n()
   const navigate = useNavigate()
 
+  const isAssistantEnabled = flag('cozy.assistant.enabled')
+
   return (
     <CozyTheme variant="normal">
       <div
@@ -43,7 +45,9 @@ export const AssistantWrapperMobile = () => {
             <Icon className="u-ml-1 u-mr-half" icon={AssistantIcon} size={24} />
           }
           type="button"
-          label={t('assistant.search.placeholder')}
+          label={
+            isAssistantEnabled ? t('assistant.search.placeholder') : undefined // Fallback on SearchBar default
+          }
           onClick={() => navigate('connected/search')}
         />
       </div>

--- a/src/assistant/Search/SearchBarDesktop.jsx
+++ b/src/assistant/Search/SearchBarDesktop.jsx
@@ -24,8 +24,10 @@ const SearchBarDesktop = ({ value, onClear, onChange }) => {
   const searchRef = useRef()
   const listRef = useRef()
 
+  const isAssistantEnabled = flag('cozy.assistant.enabled')
+
   const handleClick = () => {
-    if (!flag('cozy.assistant.enabled')) return
+    if (!isAssistantEnabled) return
 
     const conversationId = makeConversationId()
     onAssistantExecute({ value, conversationId })
@@ -84,7 +86,9 @@ const SearchBarDesktop = ({ value, onClear, onChange }) => {
           ref={searchRef}
           size="large"
           icon={<Icon className="u-mh-1" icon={AssistantIcon} size={32} />}
-          placeholder={t('assistant.search.placeholder')}
+          placeholder={
+            isAssistantEnabled ? t('assistant.search.placeholder') : undefined // Fallback on SearchBar default
+          }
           value={value}
           componentsProps={{
             inputBase: { onKeyDown: handleKeyDown }


### PR DESCRIPTION
When the assistant is enabled, the search wording suggests the user to ask a question, that could be answered by the assistant or the search. But if the assistant is not enabled, we should adapt the wording to focus on search only.



```
### ✨ Features

* Adapt search placeholder if assistant is not enabled

### 🐛 Bug Fixes

*

### 🔧 Tech

*
```
