### PR TITLE
feat: ios-style folders on the home grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   },
   "homepage": "https://github.com/cozy/cozy-home#readme",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@linagora/twake-icons": "^2.6.7",
     "@sentry/react": "7.119.0",
     "cozy-bar": "^35.1.0",

--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -20,7 +20,7 @@ const {
   applications: { sortApplicationsList, checkEntrypointCondition }
 } = models
 
-const LoadingAppTiles = memo(({ num }) => {
+export const LoadingAppTiles = memo(({ num }) => {
   const { t } = useI18n()
   return (
     <>

--- a/src/components/ApplicationsAndServices/FolderDialog.spec.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.spec.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { FolderDialog } from './FolderDialog'
-import { FolderItem } from './homeLayout'
+import { FolderItem } from './types'
 
 import AppLike from '@/test/AppLike'
 

--- a/src/components/ApplicationsAndServices/FolderDialog.spec.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.spec.tsx
@@ -65,9 +65,10 @@ describe('FolderDialog', () => {
     expect(onRename).toHaveBeenCalledWith('folder:x', 'Comptes')
   })
 
-  it('dissolves', () => {
+  it('dissolves from the actions menu', () => {
     const { onDissolve } = setup()
-    fireEvent.click(screen.getByTestId('folder-dissolve'))
+    fireEvent.click(screen.getByTestId('folder-menu'))
+    fireEvent.click(screen.getByText('Dissolve the folder'))
     expect(onDissolve).toHaveBeenCalledWith('folder:x')
   })
 

--- a/src/components/ApplicationsAndServices/FolderDialog.spec.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.spec.tsx
@@ -1,0 +1,79 @@
+import { DndContext } from '@dnd-kit/core'
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { FolderDialog } from './FolderDialog'
+import { FolderItem } from './homeLayout'
+
+import AppLike from '@/test/AppLike'
+
+jest.mock('@/components/AppTile', () => ({
+  __esModule: true,
+  default: ({ app }: { app: { slug: string } }): JSX.Element => (
+    <div data-testid="inner">{app.slug}</div>
+  )
+}))
+
+const folder: FolderItem = {
+  type: 'folder',
+  id: 'folder:x',
+  name: 'Banques',
+  items: [{ type: 'app', id: 'app:drive', app: { slug: 'drive' } as never }]
+}
+
+const setup = (
+  props = {}
+): {
+  onClose: jest.Mock
+  onRename: jest.Mock
+  onDissolve: jest.Mock
+  onRemoveItem: jest.Mock
+} => {
+  const onClose = jest.fn()
+  const onRename = jest.fn()
+  const onDissolve = jest.fn()
+  const onRemoveItem = jest.fn()
+  render(
+    <AppLike>
+      <DndContext>
+        <FolderDialog
+          folder={folder}
+          onClose={onClose}
+          onRename={onRename}
+          onDissolve={onDissolve}
+          onRemoveItem={onRemoveItem}
+          {...props}
+        />
+      </DndContext>
+    </AppLike>
+  )
+  return { onClose, onRename, onDissolve, onRemoveItem }
+}
+
+describe('FolderDialog', () => {
+  it('shows the folder name and inner tiles', () => {
+    setup()
+    expect(screen.getByDisplayValue('Banques')).toBeInTheDocument()
+    expect(screen.getByTestId('inner')).toHaveTextContent('drive')
+  })
+
+  it('renames on blur', () => {
+    const { onRename } = setup()
+    const input = screen.getByDisplayValue('Banques')
+    fireEvent.change(input, { target: { value: 'Comptes' } })
+    fireEvent.blur(input)
+    expect(onRename).toHaveBeenCalledWith('folder:x', 'Comptes')
+  })
+
+  it('dissolves', () => {
+    const { onDissolve } = setup()
+    fireEvent.click(screen.getByTestId('folder-dissolve'))
+    expect(onDissolve).toHaveBeenCalledWith('folder:x')
+  })
+
+  it('removes a single item', () => {
+    const { onRemoveItem } = setup()
+    fireEvent.click(screen.getByTestId('folder-remove-app:drive'))
+    expect(onRemoveItem).toHaveBeenCalledWith('folder:x', 'app:drive')
+  })
+})

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -63,14 +63,14 @@ export const FolderDialog = ({
   const { t } = useI18n()
   const [name, setName] = useState(folder.name)
 
-  const handleBlur = (): void => {
+  const commitRename = (): void => {
     if (name !== folder.name) onRename(folder.id, name)
   }
 
   // Persist a pending rename even when the dialog closes via Escape, which
   // dismisses before the TextField fires its blur event.
   const handleClose = (): void => {
-    handleBlur()
+    commitRename()
     onClose()
   }
 
@@ -85,7 +85,7 @@ export const FolderDialog = ({
           value={name}
           placeholder={t('folder.name_placeholder')}
           onChange={e => setName(e.target.value)}
-          onBlur={handleBlur}
+          onBlur={commitRename}
           variant="standard"
         />
       }

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -1,0 +1,136 @@
+import { SortableContext, rectSortingStrategy, useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import cx from 'classnames'
+import React, { useState } from 'react'
+
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import UntypedTextField from 'cozy-ui/transpiled/react/TextField'
+import { useI18n } from 'twake-i18n'
+
+import { TileContent } from './TileContent'
+import { FolderItem, TileItem } from './homeLayout'
+
+const TextField = UntypedTextField as React.FC<{
+  value: string
+  placeholder: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur: () => void
+  variant: string
+}>
+
+interface FolderDialogItemProps {
+  item: TileItem
+  onRemove: (itemId: string) => void
+  removeLabel: string
+}
+
+const FolderDialogItem = ({
+  item,
+  onRemove,
+  removeLabel
+}: FolderDialogItemProps): JSX.Element => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: item.id })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  }
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cx('home-folder-item', {
+        'home-folder-item--dragging': isDragging
+      })}
+      data-id={item.id}
+    >
+      <IconButton
+        className="home-folder-remove"
+        size="small"
+        aria-label={removeLabel}
+        data-testid={`folder-remove-${item.id}`}
+        onClick={() => onRemove(item.id)}
+      >
+        <Icon icon={CrossCircleOutlineIcon} size={18} />
+      </IconButton>
+      <div className="home-folder-item-icon" {...attributes} {...listeners}>
+        <TileContent item={item} onOpenFolder={() => undefined} />
+      </div>
+    </div>
+  )
+}
+
+interface FolderDialogProps {
+  folder: FolderItem
+  onClose: () => void
+  onRename: (id: string, name: string) => void
+  onDissolve: (id: string) => void
+  onRemoveItem: (folderId: string, itemId: string) => void
+}
+
+export const FolderDialog = ({
+  folder,
+  onClose,
+  onRename,
+  onDissolve,
+  onRemoveItem
+}: FolderDialogProps): JSX.Element => {
+  const { t } = useI18n()
+  const [name, setName] = useState(folder.name)
+
+  const handleBlur = (): void => {
+    if (name !== folder.name) onRename(folder.id, name)
+  }
+
+  // Persist a pending rename even when the dialog closes via Escape, which
+  // dismisses before the TextField fires its blur event.
+  const handleClose = (): void => {
+    handleBlur()
+    onClose()
+  }
+
+  const ids = folder.items.map(i => i.id)
+
+  return (
+    <Dialog
+      open
+      onClose={handleClose}
+      title={
+        <TextField
+          value={name}
+          placeholder={t('folder.name_placeholder')}
+          onChange={e => setName(e.target.value)}
+          onBlur={handleBlur}
+          variant="standard"
+        />
+      }
+      actions={
+        <IconButton
+          aria-label={t('folder.dissolve')}
+          data-testid="folder-dissolve"
+          onClick={() => onDissolve(folder.id)}
+        >
+          <Icon icon={TrashIcon} />
+        </IconButton>
+      }
+      content={
+        <SortableContext items={ids} strategy={rectSortingStrategy}>
+          <div className="home-folder-content" data-testid="folder-content">
+            {folder.items.map(item => (
+              <FolderDialogItem
+                key={item.id}
+                item={item}
+                onRemove={id => onRemoveItem(folder.id, id)}
+                removeLabel={t('folder.remove_item')}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      }
+    />
+  )
+}

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -11,14 +11,11 @@ import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import { useI18n } from 'twake-i18n'
 
 import { TileContent } from './TileContent'
-import { FolderItem, TileItem } from './homeLayout'
-import { TextField } from './types'
-
-interface FolderDialogItemProps {
-  item: TileItem
-  onRemove: (itemId: string) => void
-  removeLabel: string
-}
+import {
+  FolderDialogItemProps,
+  FolderDialogProps,
+  TextField
+} from './types'
 
 const FolderDialogItem = ({
   item,
@@ -54,14 +51,6 @@ const FolderDialogItem = ({
       </div>
     </div>
   )
-}
-
-interface FolderDialogProps {
-  folder: FolderItem
-  onClose: () => void
-  onRename: (id: string, name: string) => void
-  onDissolve: (id: string) => void
-  onRemoveItem: (folderId: string, itemId: string) => void
 }
 
 export const FolderDialog = ({

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -7,12 +7,14 @@ import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import React, { useRef, useState } from 'react'
 
+import {
+  Icon,
+  CrossCircleOutline as CrossCircleOutlineIcon,
+  Dots as DotsIcon,
+  Trash as TrashIcon
+} from '@linagora/twake-icons'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
-import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
-import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
-import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
-import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
 import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
 import { useI18n } from 'twake-i18n'
 

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -1,4 +1,8 @@
-import { SortableContext, rectSortingStrategy, useSortable } from '@dnd-kit/sortable'
+import {
+  SortableContext,
+  rectSortingStrategy,
+  useSortable
+} from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import React, { useRef, useState } from 'react'
@@ -7,13 +11,18 @@ import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
+import DotsIcon from 'cozy-ui/transpiled/react/Icons/Dots'
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+import CozyTheme from 'cozy-ui-plus/dist/providers/CozyTheme'
 import { useI18n } from 'twake-i18n'
 
 import { TileContent } from './TileContent'
 import {
+  ActionsMenu,
   FolderDialogItemProps,
   FolderDialogProps,
+  makeAction,
+  makeActions,
   TextField
 } from './types'
 
@@ -22,8 +31,14 @@ const FolderDialogItem = ({
   onRemove,
   removeLabel
 }: FolderDialogItemProps): JSX.Element => {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: item.id })
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id: item.id })
   const style = {
     transform: CSS.Transform.toString(transform),
     transition
@@ -62,6 +77,8 @@ export const FolderDialog = ({
 }: FolderDialogProps): JSX.Element => {
   const { t } = useI18n()
   const [name, setName] = useState(folder.name)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const anchorRef = useRef<HTMLButtonElement>(null)
   // Tracks the last persisted name so blur and close (which both fire when the
   // dialog is dismissed) do not save the same rename twice.
   const committedNameRef = useRef(folder.name)
@@ -81,43 +98,65 @@ export const FolderDialog = ({
   }
 
   const ids = folder.items.map(i => i.id)
+  const actions = makeActions([
+    (): unknown =>
+      makeAction({
+        name: 'DissolveFolder',
+        icon: TrashIcon,
+        label: t('folder.dissolve'),
+        action: () => onDissolve(folder.id)
+      })
+  ])
 
   return (
-    <Dialog
-      open
-      onClose={handleClose}
-      title={
-        <TextField
-          value={name}
-          placeholder={t('folder.name_placeholder')}
-          onChange={e => setName(e.target.value)}
-          onBlur={commitRename}
-          variant="standard"
-        />
-      }
-      actions={
-        <IconButton
-          aria-label={t('folder.dissolve')}
-          data-testid="folder-dissolve"
-          onClick={() => onDissolve(folder.id)}
-        >
-          <Icon icon={TrashIcon} />
-        </IconButton>
-      }
-      content={
-        <SortableContext items={ids} strategy={rectSortingStrategy}>
-          <div className="home-folder-content" data-testid="folder-content">
-            {folder.items.map(item => (
-              <FolderDialogItem
-                key={item.id}
-                item={item}
-                onRemove={id => onRemoveItem(folder.id, id)}
-                removeLabel={t('folder.remove_item')}
-              />
-            ))}
+    <>
+      <Dialog
+        open
+        onClose={handleClose}
+        title={
+          <div className="u-flex u-flex-items-center u-flex-justify-between">
+            <TextField
+              value={name}
+              placeholder={t('folder.name_placeholder')}
+              onChange={e => setName(e.target.value)}
+              onBlur={commitRename}
+              variant="standard"
+            />
+            <IconButton
+              ref={anchorRef}
+              size="small"
+              aria-label={t('folder.actions')}
+              data-testid="folder-menu"
+              onClick={() => setMenuOpen(true)}
+            >
+              <Icon icon={DotsIcon} rotate={90} />
+            </IconButton>
           </div>
-        </SortableContext>
-      }
-    />
+        }
+        content={
+          <SortableContext items={ids} strategy={rectSortingStrategy}>
+            <div className="home-folder-content" data-testid="folder-content">
+              {folder.items.map(item => (
+                <FolderDialogItem
+                  key={item.id}
+                  item={item}
+                  onRemove={id => onRemoveItem(folder.id, id)}
+                  removeLabel={t('folder.remove_item')}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        }
+      />
+      <CozyTheme>
+        <ActionsMenu
+          ref={anchorRef}
+          open={menuOpen}
+          actions={actions}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          onClose={() => setMenuOpen(false)}
+        />
+      </CozyTheme>
+    </>
   )
 }

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -8,19 +8,11 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import IconButton from 'cozy-ui/transpiled/react/IconButton'
 import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
 import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
-import UntypedTextField from 'cozy-ui/transpiled/react/TextField'
 import { useI18n } from 'twake-i18n'
 
 import { TileContent } from './TileContent'
 import { FolderItem, TileItem } from './homeLayout'
-
-const TextField = UntypedTextField as React.FC<{
-  value: string
-  placeholder: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onBlur: () => void
-  variant: string
-}>
+import { TextField } from './types'
 
 interface FolderDialogItemProps {
   item: TileItem

--- a/src/components/ApplicationsAndServices/FolderDialog.tsx
+++ b/src/components/ApplicationsAndServices/FolderDialog.tsx
@@ -1,7 +1,7 @@
 import { SortableContext, rectSortingStrategy, useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Icon from 'cozy-ui/transpiled/react/Icon'
@@ -62,9 +62,15 @@ export const FolderDialog = ({
 }: FolderDialogProps): JSX.Element => {
   const { t } = useI18n()
   const [name, setName] = useState(folder.name)
+  // Tracks the last persisted name so blur and close (which both fire when the
+  // dialog is dismissed) do not save the same rename twice.
+  const committedNameRef = useRef(folder.name)
 
   const commitRename = (): void => {
-    if (name !== folder.name) onRename(folder.id, name)
+    if (name !== committedNameRef.current) {
+      committedNameRef.current = name
+      onRename(folder.id, name)
+    }
   }
 
   // Persist a pending rename even when the dialog closes via Escape, which

--- a/src/components/ApplicationsAndServices/FolderTile.tsx
+++ b/src/components/ApplicationsAndServices/FolderTile.tsx
@@ -1,20 +1,14 @@
 import React from 'react'
 
 import { models } from 'cozy-client'
-import UntypedAppIcon from 'cozy-ui-plus/dist/AppIcon'
 import SquareAppIcon from 'cozy-ui-plus/dist/SquareAppIcon'
 
 import { FolderItem, TileItem } from './homeLayout'
+import { AppIcon } from './types'
 
 const {
   file: { getShortcutImgSrc }
 } = models
-
-const AppIcon = UntypedAppIcon as React.FC<{
-  app: unknown
-  type?: 'app' | 'konnector'
-  className?: string
-}>
 
 // A single inner item rendered as a small icon for the folder preview. Every
 // item type resolves to the same square so the preview stays uniform.

--- a/src/components/ApplicationsAndServices/FolderTile.tsx
+++ b/src/components/ApplicationsAndServices/FolderTile.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+
+import { models } from 'cozy-client'
+import UntypedAppIcon from 'cozy-ui-plus/dist/AppIcon'
+import SquareAppIcon from 'cozy-ui-plus/dist/SquareAppIcon'
+
+import { FolderItem, TileItem } from './homeLayout'
+
+const {
+  file: { getShortcutImgSrc }
+} = models
+
+const AppIcon = UntypedAppIcon as React.FC<{
+  app: unknown
+  type?: 'app' | 'konnector'
+  className?: string
+}>
+
+// A single inner item rendered as a small icon for the folder preview. Every
+// item type resolves to the same square so the preview stays uniform.
+const PreviewIcon = ({ item }: { item: TileItem }): JSX.Element | null => {
+  switch (item.type) {
+    case 'app':
+      return (
+        <AppIcon
+          app={item.app}
+          type="app"
+          className="home-folder-preview-img"
+        />
+      )
+    case 'konnector':
+      return (
+        <AppIcon
+          app={item.konnector}
+          type="konnector"
+          className="home-folder-preview-img"
+        />
+      )
+    case 'shortcut': {
+      const src = getShortcutImgSrc(item.file)
+      return src ? (
+        <img className="home-folder-preview-img" src={src} alt="" />
+      ) : null
+    }
+    case 'entrypoint':
+      return (
+        <img
+          className="home-folder-preview-img"
+          src={`data:image/svg+xml;base64,${item.entrypoint.icon}`}
+          alt=""
+        />
+      )
+    default:
+      return null
+  }
+}
+
+interface FolderTileProps {
+  folder: FolderItem
+  onOpen: (id: string) => void
+}
+
+export const FolderTile = ({
+  folder,
+  onOpen
+}: FolderTileProps): JSX.Element => {
+  const preview = folder.items.slice(0, 4)
+  return (
+    <button
+      type="button"
+      className="scale-hover home-folder-tile"
+      onClick={() => onOpen(folder.id)}
+      data-testid="folder-tile"
+    >
+      <SquareAppIcon
+        name={folder.name}
+        variant="shortcut"
+        hideShortcutBadge
+        IconContent={
+          <div className="home-folder-preview">
+            {preview.map(item => (
+              <div
+                key={item.id}
+                className="home-folder-preview-cell"
+                data-icon-id={item.id}
+              >
+                <PreviewIcon item={item} />
+              </div>
+            ))}
+          </div>
+        }
+      />
+    </button>
+  )
+}

--- a/src/components/ApplicationsAndServices/FolderTile.tsx
+++ b/src/components/ApplicationsAndServices/FolderTile.tsx
@@ -3,8 +3,7 @@ import React from 'react'
 import { models } from 'cozy-client'
 import SquareAppIcon from 'cozy-ui-plus/dist/SquareAppIcon'
 
-import { FolderItem, TileItem } from './homeLayout'
-import { AppIcon } from './types'
+import { AppIcon, FolderTileProps, TileItem } from './types'
 
 const {
   file: { getShortcutImgSrc }
@@ -47,11 +46,6 @@ const PreviewIcon = ({ item }: { item: TileItem }): JSX.Element | null => {
     default:
       return null
   }
-}
-
-interface FolderTileProps {
-  folder: FolderItem
-  onOpen: (id: string) => void
 }
 
 export const FolderTile = ({

--- a/src/components/ApplicationsAndServices/LegacyApplicationsAndServices.jsx
+++ b/src/components/ApplicationsAndServices/LegacyApplicationsAndServices.jsx
@@ -3,16 +3,17 @@ import React from 'react'
 import flag from 'cozy-flags'
 import { useBreakpoints } from 'cozy-ui/transpiled/react/providers/Breakpoints'
 
-import AddTile from './AddTile'
-import { useApps } from './Applications'
-import AssistantTile from './AssistantTile'
-import { useServices } from './Services'
-
+import AddTile from '@/components/AddTile'
+import { useApps } from '@/components/Applications'
+import AssistantTile from '@/components/AssistantTile'
 import EntrypointLink from '@/components/EntrypointLink'
 import LogoutTile from '@/components/LogoutTile'
+import { useServices } from '@/components/Services'
 import ShortcutLink from '@/components/ShortcutLink'
 
-export const ApplicationsAndServices = () => {
+// Home tile list as it was before the folders feature. Rendered when the
+// `home.apps.folders` flag is off, so the feature can ship dark.
+export const LegacyApplicationsAndServices = () => {
   const showLogout = !!flag('home.mainlist.show-logout')
   const { appsComponents, apps, shortcuts, entrypoints } = useApps()
   const { konnectors } = useServices()
@@ -39,4 +40,4 @@ export const ApplicationsAndServices = () => {
   )
 }
 
-export default ApplicationsAndServices
+export default LegacyApplicationsAndServices

--- a/src/components/ApplicationsAndServices/SortableTile.tsx
+++ b/src/components/ApplicationsAndServices/SortableTile.tsx
@@ -4,13 +4,7 @@ import cx from 'classnames'
 import React, { memo } from 'react'
 
 import { TileContent } from './TileContent'
-import { GridItem } from './homeLayout'
-
-interface SortableTileProps {
-  item: GridItem
-  combineTarget: boolean
-  onOpenFolder: (id: string) => void
-}
+import { SortableTileProps } from './types'
 
 const SortableTileComponent = ({
   item,

--- a/src/components/ApplicationsAndServices/SortableTile.tsx
+++ b/src/components/ApplicationsAndServices/SortableTile.tsx
@@ -1,0 +1,45 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import cx from 'classnames'
+import React, { memo } from 'react'
+
+import { TileContent } from './TileContent'
+import { GridItem } from './homeLayout'
+
+interface SortableTileProps {
+  item: GridItem
+  combineTarget: boolean
+  onOpenFolder: (id: string) => void
+}
+
+const SortableTileComponent = ({
+  item,
+  combineTarget,
+  onOpenFolder
+}: SortableTileProps): JSX.Element => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: item.id })
+  // The dragged tile stays faded in place (the DragOverlay represents it);
+  // siblings take the shuffle transform so they slide aside to make room.
+  const style = {
+    transform: isDragging ? undefined : CSS.Transform.toString(transform),
+    transition
+  }
+  return (
+    <div
+      ref={setNodeRef}
+      data-id={item.id}
+      style={style}
+      className={cx('home-item', {
+        'home-item--placeholder': isDragging,
+        'home-item--combine': combineTarget
+      })}
+      {...attributes}
+      {...listeners}
+    >
+      <TileContent item={item} onOpenFolder={onOpenFolder} />
+    </div>
+  )
+}
+
+export const SortableTile = memo(SortableTileComponent)

--- a/src/components/ApplicationsAndServices/TileContent.tsx
+++ b/src/components/ApplicationsAndServices/TileContent.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { FolderTile } from './FolderTile'
+import { GridItem } from './homeLayout'
+
+import AppTile from '@/components/AppTile'
+import EntrypointLink from '@/components/EntrypointLink'
+import KonnectorTile from '@/components/KonnectorTile'
+import ShortcutLink from '@/components/ShortcutLink'
+
+interface TileContentProps {
+  item: GridItem
+  onOpenFolder: (id: string) => void
+}
+
+export const TileContent = ({
+  item,
+  onOpenFolder
+}: TileContentProps): JSX.Element | null => {
+  switch (item.type) {
+    case 'app':
+      return <AppTile app={item.app} />
+    case 'konnector':
+      return (
+        <KonnectorTile
+          konnector={item.konnector}
+          isInMaintenance={item.isInMaintenance}
+          loading={item.isRunning}
+        />
+      )
+    case 'shortcut':
+      return <ShortcutLink file={item.file} />
+    case 'entrypoint':
+      return <EntrypointLink entrypoint={item.entrypoint} />
+    case 'folder':
+      return <FolderTile folder={item} onOpen={onOpenFolder} />
+    default:
+      return null
+  }
+}

--- a/src/components/ApplicationsAndServices/TileContent.tsx
+++ b/src/components/ApplicationsAndServices/TileContent.tsx
@@ -1,17 +1,12 @@
 import React from 'react'
 
 import { FolderTile } from './FolderTile'
-import { GridItem } from './homeLayout'
+import { TileContentProps } from './types'
 
 import AppTile from '@/components/AppTile'
 import EntrypointLink from '@/components/EntrypointLink'
 import KonnectorTile from '@/components/KonnectorTile'
 import ShortcutLink from '@/components/ShortcutLink'
-
-interface TileContentProps {
-  item: GridItem
-  onOpenFolder: (id: string) => void
-}
 
 export const TileContent = ({
   item,

--- a/src/components/ApplicationsAndServices/dndGeometry.ts
+++ b/src/components/ApplicationsAndServices/dndGeometry.ts
@@ -1,0 +1,47 @@
+import { DragEndEvent, DragMoveEvent } from '@dnd-kit/core'
+
+// How long the dragged tile must hover (hold) over another tile before the
+// gesture is treated as "into the group": a regular tile folds into a new
+// folder, a folder springs open so the icon can be dropped straight inside.
+export const DWELL_MS = 450
+
+// Fraction of each tile trimmed off every edge to form its central "group"
+// zone. The dragged tile's centre must sit inside this zone for a hold to fold
+// or spring a folder; elsewhere the drag just reorders.
+export const CENTRAL_INSET = 0.25
+
+// No-op sorting strategy: keeps grid tiles in place during a drag. Live
+// shuffling would slide the hovered tile out from under the pointer, making a
+// stable "hold" gesture impossible. Grid reorder is committed on drop instead.
+export const noSortStrategy = (): null => null
+
+// True when the dragged tile's centre is inside the over tile's central zone.
+export const isOverCentre = (
+  active: DragMoveEvent['active'],
+  over: DragMoveEvent['over']
+): boolean => {
+  const a = active.rect.current.translated
+  const r = over?.rect
+  if (!a || !r) return false
+  const cx = a.left + a.width / 2
+  const cy = a.top + a.height / 2
+  const ix = r.width * CENTRAL_INSET
+  const iy = r.height * CENTRAL_INSET
+  return (
+    cx >= r.left + ix &&
+    cx <= r.right - ix &&
+    cy >= r.top + iy &&
+    cy <= r.bottom - iy
+  )
+}
+
+// True when the dragged tile's centre is outside the open folder dialog.
+export const isOutsideDialog = (active: DragEndEvent['active']): boolean => {
+  const a = active.rect.current.translated
+  const dialogEl = document.querySelector('[role="dialog"]')
+  if (!a || !dialogEl) return false
+  const r = dialogEl.getBoundingClientRect()
+  const cx = a.left + a.width / 2
+  const cy = a.top + a.height / 2
+  return cx < r.left || cx > r.right || cy < r.top || cy > r.bottom
+}

--- a/src/components/ApplicationsAndServices/homeLayout.spec.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.spec.ts
@@ -123,9 +123,9 @@ describe('folderCategoryFromDoc', () => {
   })
 
   it('prefers a non-empty categories array over the singular field', () => {
-    expect(folderCategoryFromDoc({ categories: ['health'], category: 'cozy' })).toBe(
-      'health'
-    )
+    expect(
+      folderCategoryFromDoc({ categories: ['health'], category: 'cozy' })
+    ).toBe('health')
   })
 
   it('returns null when neither yields a usable category', () => {

--- a/src/components/ApplicationsAndServices/homeLayout.spec.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.spec.ts
@@ -9,7 +9,6 @@ import {
   buildKonnectorItems,
   buildShortcutItems,
   createFolder,
-  createFolderFromTile,
   dissolveFolder,
   folderCategoryFromDoc,
   isFolderId,
@@ -247,16 +246,6 @@ describe('folder operations', () => {
     const next = addToFolder(start, 'folder:x', 'app:notes')
     expect(next.order).toEqual(['folder:x'])
     expect(next.folders['folder:x'].items).toEqual(['app:drive', 'app:notes'])
-  })
-
-  it('createFolderFromTile makes a single-item folder at the tile slot', () => {
-    const start = {
-      order: ['app:drive', 'app:notes', 'app:photos'],
-      folders: {} as Record<string, { name: string; items: string[] }>
-    }
-    const next = createFolderFromTile(start, 'app:notes', 'folder:x', 'New')
-    expect(next.order).toEqual(['app:drive', 'folder:x', 'app:photos'])
-    expect(next.folders['folder:x']).toEqual({ name: 'New', items: ['app:notes'] })
   })
 
   it('addToFolderAt inserts the dragged id at the given index', () => {

--- a/src/components/ApplicationsAndServices/homeLayout.spec.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.spec.ts
@@ -1,7 +1,6 @@
 import type { IOCozyApp, IOCozyKonnector } from 'cozy-client/types/types'
 
 import {
-  AppItem,
   addToFolder,
   addToFolderAt,
   buildAppItems,
@@ -19,6 +18,7 @@ import {
   renameFolder,
   reorderFolderItems
 } from './homeLayout'
+import type { AppItem } from './types'
 
 const makeApp = (slug: string, state = 'ready'): IOCozyApp =>
   ({ slug, state }) as unknown as IOCozyApp

--- a/src/components/ApplicationsAndServices/homeLayout.spec.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.spec.ts
@@ -1,0 +1,371 @@
+import type { IOCozyApp, IOCozyKonnector } from 'cozy-client/types/types'
+
+import {
+  AppItem,
+  addToFolder,
+  addToFolderAt,
+  buildAppItems,
+  buildGrid,
+  buildKonnectorItems,
+  buildShortcutItems,
+  createFolder,
+  createFolderFromTile,
+  dissolveFolder,
+  folderCategoryFromDoc,
+  isFolderId,
+  makeAppId,
+  makeFolderId,
+  pickFolderCategory,
+  removeFromFolder,
+  renameFolder,
+  reorderFolderItems
+} from './homeLayout'
+
+const makeApp = (slug: string, state = 'ready'): IOCozyApp =>
+  ({ slug, state }) as unknown as IOCozyApp
+
+describe('buildAppItems', () => {
+  const noFilters = { sortSlugs: null, hiddenSlugs: [], hiddenHomeSlugs: [] }
+
+  it('returns [] without apps', () => {
+    expect(buildAppItems(null, noFilters)).toEqual([])
+  })
+
+  it('filters hidden/home-hidden/hidden-state/home and dedups, then ids', () => {
+    const items = buildAppItems(
+      [
+        makeApp('drive'),
+        makeApp('ghost', 'hidden'),
+        makeApp('home'),
+        makeApp('drive')
+      ],
+      { sortSlugs: null, hiddenSlugs: [], hiddenHomeSlugs: [] }
+    )
+    expect(items.map(i => i.id)).toEqual(['app:drive'])
+  })
+
+  it('applies the sort flag, unknown slugs last', () => {
+    const items = buildAppItems(
+      [makeApp('notes'), makeApp('drive'), makeApp('zz')],
+      {
+        ...noFilters,
+        sortSlugs: ['drive', 'notes']
+      }
+    )
+    expect(items.map(i => i.id)).toEqual(['app:drive', 'app:notes', 'app:zz'])
+  })
+})
+
+describe('buildKonnectorItems', () => {
+  it('flags maintenance and running', () => {
+    const ks = [
+      { slug: 'alan', name: 'Alan' },
+      { slug: 'edf', name: 'EDF' }
+    ] as unknown as IOCozyKonnector[]
+    const items = buildKonnectorItems(ks, new Set(['edf']), ['alan'])
+    expect(items).toEqual([
+      {
+        type: 'konnector',
+        id: 'konnector:alan',
+        konnector: ks[0],
+        isInMaintenance: false,
+        isRunning: true
+      },
+      {
+        type: 'konnector',
+        id: 'konnector:edf',
+        konnector: ks[1],
+        isInMaintenance: true,
+        isRunning: false
+      }
+    ])
+  })
+})
+
+describe('buildShortcutItems', () => {
+  it('builds ids from _id', () => {
+    expect(
+      buildShortcutItems([{ _id: 'abc' }] as never).map(i => i.id)
+    ).toEqual(['shortcut:abc'])
+  })
+  it('returns [] when not loaded', () => {
+    expect(buildShortcutItems(null)).toEqual([])
+  })
+})
+
+describe('folder ids', () => {
+  it('generates unique folder ids recognised by isFolderId', () => {
+    const id = makeFolderId()
+    expect(isFolderId(id)).toBe(true)
+    expect(isFolderId(makeAppId('drive'))).toBe(false)
+    expect(id).not.toEqual(makeFolderId())
+  })
+})
+
+describe('pickFolderCategory', () => {
+  it('returns the first category', () => {
+    expect(pickFolderCategory(['banking', 'finance'])).toBe('banking')
+  })
+
+  it('ignores the catch-all "others" and empty/missing lists', () => {
+    expect(pickFolderCategory(['others'])).toBe(null)
+    expect(pickFolderCategory([])).toBe(null)
+    expect(pickFolderCategory(undefined)).toBe(null)
+  })
+})
+
+describe('folderCategoryFromDoc', () => {
+  it('reads the modern categories array', () => {
+    expect(folderCategoryFromDoc({ categories: ['banking'] })).toBe('banking')
+  })
+
+  it('falls back to the legacy singular category', () => {
+    expect(folderCategoryFromDoc({ category: 'cozy' })).toBe('cozy')
+  })
+
+  it('prefers a non-empty categories array over the singular field', () => {
+    expect(folderCategoryFromDoc({ categories: ['health'], category: 'cozy' })).toBe(
+      'health'
+    )
+  })
+
+  it('returns null when neither yields a usable category', () => {
+    expect(folderCategoryFromDoc({ categories: [] })).toBe(null)
+    expect(folderCategoryFromDoc({ category: 'others' })).toBe(null)
+    expect(folderCategoryFromDoc(undefined)).toBe(null)
+  })
+})
+
+const app = (slug: string): AppItem => ({
+  type: 'app',
+  id: `app:${slug}`,
+  app: { slug } as AppItem['app']
+})
+
+describe('buildGrid', () => {
+  const items = [app('drive'), app('notes'), app('photos')]
+
+  it('keeps default order when nothing saved', () => {
+    const grid = buildGrid({ order: [], folders: {} }, items)
+    expect(grid.map(g => g.id)).toEqual([
+      'app:drive',
+      'app:notes',
+      'app:photos'
+    ])
+  })
+
+  it('applies saved order, appends new items, drops stale ids', () => {
+    const grid = buildGrid(
+      { order: ['app:gone', 'app:notes'], folders: {} },
+      items
+    )
+    expect(grid.map(g => g.id)).toEqual([
+      'app:notes',
+      'app:drive',
+      'app:photos'
+    ])
+  })
+
+  it('materialises folders with their live inner items, name and position', () => {
+    const grid = buildGrid(
+      {
+        order: ['app:drive', 'folder:a'],
+        folders: {
+          'folder:a': { name: 'G', items: ['app:photos', 'app:notes'] }
+        }
+      },
+      items
+    )
+    expect(grid[0].id).toBe('app:drive')
+    const folder = grid[1]
+    expect(folder.type).toBe('folder')
+    if (folder.type === 'folder') {
+      expect(folder.name).toBe('G')
+      expect(folder.items.map(i => i.id)).toEqual(['app:photos', 'app:notes'])
+    }
+  })
+
+  it('drops empty folders (all inner items stale)', () => {
+    const grid = buildGrid(
+      {
+        order: ['folder:a', 'app:drive'],
+        folders: { 'folder:a': { name: 'G', items: ['app:gone'] } }
+      },
+      items
+    )
+    expect(grid.map(g => g.id)).toEqual([
+      'app:drive',
+      'app:notes',
+      'app:photos'
+    ])
+  })
+
+  it('renders folders missing from order so their items are never lost', () => {
+    const grid = buildGrid(
+      {
+        order: [],
+        folders: { 'folder:a': { name: 'G', items: ['app:drive', 'app:notes'] } }
+      },
+      items
+    )
+    // Standalone items first, then the self-healed folder
+    expect(grid.map(g => g.id)).toEqual(['app:photos', 'folder:a'])
+    const folder = grid[1]
+    expect(folder.type).toBe('folder')
+    if (folder.type === 'folder') {
+      expect(folder.items.map(i => i.id)).toEqual(['app:drive', 'app:notes'])
+    }
+  })
+})
+
+describe('folder operations', () => {
+  const base = {
+    order: ['app:drive', 'app:notes', 'app:photos'],
+    folders: {} as Record<string, { name: string; items: string[] }>
+  }
+
+  it('puts the folder at the target slot, holding [target, dragged]', () => {
+    const next = createFolder(
+      base,
+      'app:photos',
+      'app:drive',
+      () => 'folder:x',
+      'Dossier'
+    )
+    expect(next.order).toEqual(['app:notes', 'folder:x'])
+    expect(next.folders['folder:x']).toEqual({
+      name: 'Dossier',
+      items: ['app:photos', 'app:drive']
+    })
+  })
+
+  it('addToFolder appends the dragged id and removes it from order', () => {
+    const start = {
+      order: ['folder:x', 'app:notes'],
+      folders: { 'folder:x': { name: 'G', items: ['app:drive'] } }
+    }
+    const next = addToFolder(start, 'folder:x', 'app:notes')
+    expect(next.order).toEqual(['folder:x'])
+    expect(next.folders['folder:x'].items).toEqual(['app:drive', 'app:notes'])
+  })
+
+  it('createFolderFromTile makes a single-item folder at the tile slot', () => {
+    const start = {
+      order: ['app:drive', 'app:notes', 'app:photos'],
+      folders: {} as Record<string, { name: string; items: string[] }>
+    }
+    const next = createFolderFromTile(start, 'app:notes', 'folder:x', 'New')
+    expect(next.order).toEqual(['app:drive', 'folder:x', 'app:photos'])
+    expect(next.folders['folder:x']).toEqual({ name: 'New', items: ['app:notes'] })
+  })
+
+  it('addToFolderAt inserts the dragged id at the given index', () => {
+    const start = {
+      order: ['folder:x', 'app:notes'],
+      folders: { 'folder:x': { name: 'G', items: ['app:drive', 'app:photos'] } }
+    }
+    const next = addToFolderAt(start, 'folder:x', 'app:notes', 1)
+    expect(next.order).toEqual(['folder:x'])
+    expect(next.folders['folder:x'].items).toEqual([
+      'app:drive',
+      'app:notes',
+      'app:photos'
+    ])
+  })
+
+  it('addToFolderAt clamps an out-of-range index to the end', () => {
+    const start = {
+      order: ['folder:x'],
+      folders: { 'folder:x': { name: 'G', items: ['a', 'b'] } }
+    }
+    expect(
+      addToFolderAt(start, 'folder:x', 'app:notes', 99).folders['folder:x'].items
+    ).toEqual(['a', 'b', 'app:notes'])
+  })
+
+  it('removeFromFolder moves the id back to the grid after the folder', () => {
+    const start = {
+      order: ['folder:x', 'app:notes'],
+      folders: {
+        'folder:x': {
+          name: 'G',
+          items: ['app:drive', 'app:photos', 'app:contacts']
+        }
+      }
+    }
+    const next = removeFromFolder(start, 'folder:x', 'app:drive')
+    expect(next.folders['folder:x'].items).toEqual(['app:photos', 'app:contacts'])
+    expect(next.order).toEqual(['folder:x', 'app:drive', 'app:notes'])
+  })
+
+  it('removeFromFolder keeps a folder that still has a single item', () => {
+    const start = {
+      order: ['folder:x', 'app:notes'],
+      folders: { 'folder:x': { name: 'G', items: ['app:drive', 'app:photos'] } }
+    }
+    const next = removeFromFolder(start, 'folder:x', 'app:drive')
+    expect(next.folders['folder:x'].items).toEqual(['app:photos'])
+    expect(next.order).toEqual(['folder:x', 'app:drive', 'app:notes'])
+  })
+
+  it('removeFromFolder drops the folder once it becomes empty', () => {
+    const start = {
+      order: ['folder:x', 'app:notes'],
+      folders: { 'folder:x': { name: 'G', items: ['app:drive'] } }
+    }
+    const next = removeFromFolder(start, 'folder:x', 'app:drive')
+    expect(next.folders['folder:x']).toBeUndefined()
+    expect(next.order).toEqual(['app:drive', 'app:notes'])
+  })
+
+  it('dissolveFolder spills items at the folder position and deletes it', () => {
+    const start = {
+      order: ['app:notes', 'folder:x'],
+      folders: { 'folder:x': { name: 'G', items: ['app:drive', 'app:photos'] } }
+    }
+    const next = dissolveFolder(start, 'folder:x')
+    expect(next.order).toEqual(['app:notes', 'app:drive', 'app:photos'])
+    expect(next.folders['folder:x']).toBeUndefined()
+  })
+
+  it('reorderFolderItems sets a new item order inside the folder', () => {
+    const start = {
+      order: ['folder:x'],
+      folders: { 'folder:x': { name: 'G', items: ['a', 'b', 'c'] } }
+    }
+    const next = reorderFolderItems(start, 'folder:x', ['c', 'a', 'b'])
+    expect(next.folders['folder:x'].items).toEqual(['c', 'a', 'b'])
+    expect(next.order).toEqual(['folder:x'])
+  })
+
+  it('renameFolder sets the name', () => {
+    const start = {
+      order: ['folder:x'],
+      folders: { 'folder:x': { name: 'G', items: ['a', 'b'] } }
+    }
+    expect(
+      renameFolder(start, 'folder:x', 'Banques').folders['folder:x'].name
+    ).toBe('Banques')
+  })
+
+  it('createFolder is a no-op when the dragged tile is a folder (no nesting)', () => {
+    const start = {
+      order: ['folder:a', 'app:notes'],
+      folders: { 'folder:a': { name: 'G', items: ['app:x', 'app:y'] } }
+    }
+    expect(
+      createFolder(start, 'app:notes', 'folder:a', () => 'folder:z')
+    ).toEqual(start)
+  })
+
+  it('addToFolder is a no-op when the dragged tile is a folder (no nesting)', () => {
+    const start = {
+      order: ['folder:a', 'folder:b'],
+      folders: {
+        'folder:a': { name: 'A', items: ['app:x', 'app:y'] },
+        'folder:b': { name: 'B', items: ['app:z', 'app:w'] }
+      }
+    }
+    expect(addToFolder(start, 'folder:a', 'folder:b')).toEqual(start)
+  })
+})

--- a/src/components/ApplicationsAndServices/homeLayout.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.ts
@@ -5,61 +5,24 @@ import type {
   IOCozyKonnector
 } from 'cozy-client/types/types'
 
+import type {
+  AppFilters,
+  AppItem,
+  Entrypoint,
+  EntrypointItem,
+  FolderMap,
+  GridItem,
+  HomeLayout,
+  KonnectorItem,
+  ShortcutItem,
+  TileItem
+} from './types'
+
 import homeConfig from '@/config/home.json'
 
 const {
   applications: { sortApplicationsList, checkEntrypointCondition }
 } = models
-
-type EntrypointCondition = Parameters<typeof checkEntrypointCondition>[0]
-
-export interface Entrypoint {
-  name: string
-  slug: string
-  hash: string
-  title: Record<string, string>
-  icon: string
-  conditions?: EntrypointCondition[]
-}
-
-export interface AppItem {
-  type: 'app'
-  id: string
-  app: IOCozyApp
-}
-export interface KonnectorItem {
-  type: 'konnector'
-  id: string
-  konnector: IOCozyKonnector
-  isInMaintenance: boolean
-  isRunning: boolean
-}
-export interface ShortcutItem {
-  type: 'shortcut'
-  id: string
-  file: IOCozyFile
-}
-export interface EntrypointItem {
-  type: 'entrypoint'
-  id: string
-  entrypoint: Entrypoint
-}
-export type TileItem = AppItem | KonnectorItem | ShortcutItem | EntrypointItem
-
-export interface FolderItem {
-  type: 'folder'
-  id: string
-  name: string
-  items: TileItem[]
-}
-
-export type GridItem = TileItem | FolderItem
-
-export interface FolderData {
-  name: string
-  items: string[]
-}
-export type FolderMap = Record<string, FolderData>
 
 const FOLDER_PREFIX = 'folder:'
 // First manifest category usable as a default folder name. Skips the catch-all
@@ -91,12 +54,6 @@ export const makeEntrypointId = (slug: string, name: string): string =>
 export const makeFolderId = (): string =>
   `${FOLDER_PREFIX}${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
 export const isFolderId = (id: string): boolean => id.startsWith(FOLDER_PREFIX)
-
-interface AppFilters {
-  sortSlugs: string[] | null
-  hiddenSlugs: string[]
-  hiddenHomeSlugs: string[]
-}
 
 export const buildAppItems = (
   apps: IOCozyApp[] | null | undefined,
@@ -144,11 +101,6 @@ export const buildShortcutItems = (
     id: makeShortcutId(file._id),
     file
   }))
-}
-
-export interface HomeLayout {
-  order: string[]
-  folders: FolderMap
 }
 
 const omit = (folders: FolderMap, id: string): FolderMap => {

--- a/src/components/ApplicationsAndServices/homeLayout.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.ts
@@ -10,11 +10,7 @@ import type {
 import homeConfig from '@/config/home.json'
 
 const {
-  applications: {
-    sortApplicationsList,
-    selectEntrypoints,
-    checkEntrypointCondition
-  }
+  applications: { sortApplicationsList, checkEntrypointCondition }
 } = models
 
 type EntrypointCondition = Parameters<typeof checkEntrypointCondition>[0]
@@ -352,24 +348,19 @@ export const buildEntrypointItems = (
   apps: IOCozyApp[] | null | undefined
 ): EntrypointItem[] => {
   if (!Array.isArray(apps)) return []
-  const drive = apps.find(a => a.slug === 'drive') as
-    | (IOCozyApp & { entrypoints?: Entrypoint[] })
-    | undefined
-  if (!drive) return []
-  const selected = selectEntrypoints(drive.entrypoints ?? [], [
-    'new-file-type-text',
-    'new-file-type-sheet',
-    'new-file-type-slide'
-  ]) as Entrypoint[]
-  const filtered = selected.filter(ep =>
-    (ep.conditions ?? []).every(c => {
-      if (c.type === 'flag' && c.name === 'bar.onlyoffice.enabled') return true
-      return checkEntrypointCondition(c)
-    })
+  return apps.flatMap(app =>
+    ((app as IOCozyApp & { entrypoints?: Entrypoint[] }).entrypoints ?? [])
+      .filter(ep =>
+        (ep.conditions ?? []).every(c => {
+          if (c.type === 'flag' && c.name === 'bar.onlyoffice.enabled')
+            return true
+          return checkEntrypointCondition(c)
+        })
+      )
+      .map(ep => ({
+        type: 'entrypoint' as const,
+        id: makeEntrypointId(app.slug, ep.name),
+        entrypoint: { ...ep, slug: app.slug }
+      }))
   )
-  return filtered.map(ep => ({
-    type: 'entrypoint',
-    id: makeEntrypointId(drive.slug, ep.name),
-    entrypoint: { ...ep, slug: drive.slug }
-  }))
 }

--- a/src/components/ApplicationsAndServices/homeLayout.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.ts
@@ -1,5 +1,3 @@
-import uniqBy from 'lodash/uniqBy'
-
 import { models } from 'cozy-client'
 import type {
   IOCozyApp,
@@ -112,7 +110,12 @@ export const buildAppItems = (
       !hiddenSlugs.includes(app.slug.toLowerCase()) &&
       !hiddenHomeSlugs.includes(app.slug.toLowerCase())
   )
-  const deduped = uniqBy(visible, 'slug')
+  const seenSlugs = new Set<string>()
+  const deduped = visible.filter(app => {
+    if (seenSlugs.has(app.slug)) return false
+    seenSlugs.add(app.slug)
+    return true
+  })
   const sorted = (
     sortSlugs ? sortApplicationsList(deduped, sortSlugs) : deduped
   ) as IOCozyApp[]

--- a/src/components/ApplicationsAndServices/homeLayout.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.ts
@@ -210,23 +210,6 @@ export const buildGrid = (
   return grid
 }
 
-// Creates a folder holding a single tile, taking that tile's slot. Used to
-// spring a brand-new folder open mid-drag so the dragged icon can then be
-// dropped inside it.
-export const createFolderFromTile = (
-  layout: HomeLayout,
-  tileId: string,
-  folderId: string,
-  name = ''
-): HomeLayout => {
-  if (isFolderId(tileId)) return layout
-  const order = layout.order.map(id => (id === tileId ? folderId : id))
-  return {
-    order,
-    folders: { ...layout.folders, [folderId]: { name, items: [tileId] } }
-  }
-}
-
 export const createFolder = (
   layout: HomeLayout,
   targetId: string,

--- a/src/components/ApplicationsAndServices/homeLayout.ts
+++ b/src/components/ApplicationsAndServices/homeLayout.ts
@@ -1,0 +1,375 @@
+import uniqBy from 'lodash/uniqBy'
+
+import { models } from 'cozy-client'
+import type {
+  IOCozyApp,
+  IOCozyFile,
+  IOCozyKonnector
+} from 'cozy-client/types/types'
+
+import homeConfig from '@/config/home.json'
+
+const {
+  applications: {
+    sortApplicationsList,
+    selectEntrypoints,
+    checkEntrypointCondition
+  }
+} = models
+
+type EntrypointCondition = Parameters<typeof checkEntrypointCondition>[0]
+
+export interface Entrypoint {
+  name: string
+  slug: string
+  hash: string
+  title: Record<string, string>
+  icon: string
+  conditions?: EntrypointCondition[]
+}
+
+export interface AppItem {
+  type: 'app'
+  id: string
+  app: IOCozyApp
+}
+export interface KonnectorItem {
+  type: 'konnector'
+  id: string
+  konnector: IOCozyKonnector
+  isInMaintenance: boolean
+  isRunning: boolean
+}
+export interface ShortcutItem {
+  type: 'shortcut'
+  id: string
+  file: IOCozyFile
+}
+export interface EntrypointItem {
+  type: 'entrypoint'
+  id: string
+  entrypoint: Entrypoint
+}
+export type TileItem = AppItem | KonnectorItem | ShortcutItem | EntrypointItem
+
+export interface FolderItem {
+  type: 'folder'
+  id: string
+  name: string
+  items: TileItem[]
+}
+
+export type GridItem = TileItem | FolderItem
+
+export interface FolderData {
+  name: string
+  items: string[]
+}
+export type FolderMap = Record<string, FolderData>
+
+const FOLDER_PREFIX = 'folder:'
+// First manifest category usable as a default folder name. Skips the catch-all
+// 'others' (and an empty list), for which a generic name reads better.
+export const pickFolderCategory = (categories?: string[]): string | null => {
+  const category = categories?.[0]
+  return category && category !== 'others' ? category : null
+}
+
+// A folder category from an app/konnector doc, handling both the modern
+// `categories` array and the legacy singular `category` string.
+export const folderCategoryFromDoc = (doc?: {
+  categories?: string[]
+  category?: string
+}): string | null => {
+  const list = doc?.categories?.length
+    ? doc.categories
+    : doc?.category
+      ? [doc.category]
+      : undefined
+  return pickFolderCategory(list)
+}
+
+export const makeAppId = (slug: string): string => `app:${slug}`
+export const makeKonnectorId = (slug: string): string => `konnector:${slug}`
+export const makeShortcutId = (fileId: string): string => `shortcut:${fileId}`
+export const makeEntrypointId = (slug: string, name: string): string =>
+  `entrypoint:${slug}:${name}`
+export const makeFolderId = (): string =>
+  `${FOLDER_PREFIX}${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+export const isFolderId = (id: string): boolean => id.startsWith(FOLDER_PREFIX)
+
+interface AppFilters {
+  sortSlugs: string[] | null
+  hiddenSlugs: string[]
+  hiddenHomeSlugs: string[]
+}
+
+export const buildAppItems = (
+  apps: IOCozyApp[] | null | undefined,
+  { sortSlugs, hiddenSlugs, hiddenHomeSlugs }: AppFilters
+): AppItem[] => {
+  if (!Array.isArray(apps) || apps.length === 0) return []
+  const visible = apps.filter(
+    app =>
+      app.state !== 'hidden' &&
+      !homeConfig.filteredApps.includes(app.slug) &&
+      !hiddenSlugs.includes(app.slug.toLowerCase()) &&
+      !hiddenHomeSlugs.includes(app.slug.toLowerCase())
+  )
+  const deduped = uniqBy(visible, 'slug')
+  const sorted = (
+    sortSlugs ? sortApplicationsList(deduped, sortSlugs) : deduped
+  ) as IOCozyApp[]
+  return sorted.map(app => ({ type: 'app', id: makeAppId(app.slug), app }))
+}
+
+export const buildKonnectorItems = (
+  konnectors: IOCozyKonnector[],
+  maintenanceSlugs: Set<string>,
+  runningSlugs: string[]
+): KonnectorItem[] =>
+  konnectors.map(konnector => ({
+    type: 'konnector',
+    id: makeKonnectorId(konnector.slug),
+    konnector,
+    isInMaintenance: maintenanceSlugs.has(konnector.slug),
+    isRunning: runningSlugs.includes(konnector.slug)
+  }))
+
+export const buildShortcutItems = (
+  files: IOCozyFile[] | null | undefined
+): ShortcutItem[] => {
+  if (!Array.isArray(files)) return []
+  return files.map(file => ({
+    type: 'shortcut',
+    id: makeShortcutId(file._id),
+    file
+  }))
+}
+
+export interface HomeLayout {
+  order: string[]
+  folders: FolderMap
+}
+
+const omit = (folders: FolderMap, id: string): FolderMap => {
+  const next = { ...folders }
+  delete next[id]
+  return next
+}
+
+// Builds the rendered grid from the saved layout and the live tile items.
+// Known ids first (saved order), then new items in default order; stale ids
+// and empty folders are dropped.
+export const buildGrid = (
+  layout: HomeLayout,
+  items: TileItem[]
+): GridItem[] => {
+  const byId = new Map(items.map(i => [i.id, i]))
+  const inFolder = new Set<string>()
+  Object.values(layout.folders).forEach(f =>
+    f.items.forEach(id => inFolder.add(id))
+  )
+
+  const placed = new Set<string>()
+  const grid: GridItem[] = []
+
+  for (const id of layout.order) {
+    if (isFolderId(id)) {
+      const data = layout.folders[id]
+      if (!data) continue
+      const inner = data.items
+        .map(i => byId.get(i))
+        .filter((i): i is TileItem => Boolean(i))
+      if (inner.length === 0) continue
+      grid.push({ type: 'folder', id, name: data.name, items: inner })
+      data.items.forEach(i => placed.add(i))
+      placed.add(id)
+    } else {
+      const item = byId.get(id)
+      if (item && !inFolder.has(id)) {
+        grid.push(item)
+        placed.add(id)
+      }
+    }
+  }
+  for (const item of items) {
+    if (!placed.has(item.id) && !inFolder.has(item.id)) grid.push(item)
+  }
+  // Self-heal: render folders that exist but were never written into `order`
+  // (e.g. created while `order` was still the empty default). Without this they
+  // would swallow their items yet never appear on the grid.
+  for (const [folderId, data] of Object.entries(layout.folders)) {
+    if (placed.has(folderId)) continue
+    const inner = data.items
+      .map(i => byId.get(i))
+      .filter((i): i is TileItem => Boolean(i))
+    if (inner.length === 0) continue
+    grid.push({ type: 'folder', id: folderId, name: data.name, items: inner })
+    placed.add(folderId)
+  }
+  return grid
+}
+
+// Creates a folder holding a single tile, taking that tile's slot. Used to
+// spring a brand-new folder open mid-drag so the dragged icon can then be
+// dropped inside it.
+export const createFolderFromTile = (
+  layout: HomeLayout,
+  tileId: string,
+  folderId: string,
+  name = ''
+): HomeLayout => {
+  if (isFolderId(tileId)) return layout
+  const order = layout.order.map(id => (id === tileId ? folderId : id))
+  return {
+    order,
+    folders: { ...layout.folders, [folderId]: { name, items: [tileId] } }
+  }
+}
+
+export const createFolder = (
+  layout: HomeLayout,
+  targetId: string,
+  draggedId: string,
+  makeId: () => string = makeFolderId,
+  name = ''
+): HomeLayout => {
+  // No nested folders: a folder can never be put inside another tile/folder.
+  if (isFolderId(draggedId)) return layout
+  // The folder takes the target's slot (where the tile was dropped, iOS-style);
+  // the dragged tile leaves its own slot and joins the folder.
+  const folderId = makeId()
+  const order = layout.order
+    .map(id => (id === targetId ? folderId : id))
+    .filter(id => id !== draggedId)
+  return {
+    order,
+    folders: {
+      ...layout.folders,
+      [folderId]: { name, items: [targetId, draggedId] }
+    }
+  }
+}
+
+export const addToFolderAt = (
+  layout: HomeLayout,
+  folderId: string,
+  draggedId: string,
+  index: number
+): HomeLayout => {
+  const folder = layout.folders[folderId]
+  if (!folder) return layout
+  if (isFolderId(draggedId)) return layout // no nested folders
+  const items = folder.items.filter(id => id !== draggedId)
+  const at = index < 0 || index > items.length ? items.length : index
+  items.splice(at, 0, draggedId)
+  return {
+    order: layout.order.filter(id => id !== draggedId),
+    folders: { ...layout.folders, [folderId]: { ...folder, items } }
+  }
+}
+
+export const addToFolder = (
+  layout: HomeLayout,
+  folderId: string,
+  draggedId: string
+): HomeLayout => {
+  const folder = layout.folders[folderId]
+  if (!folder) return layout
+  return addToFolderAt(layout, folderId, draggedId, folder.items.length)
+}
+
+export const removeFromFolder = (
+  layout: HomeLayout,
+  folderId: string,
+  itemId: string
+): HomeLayout => {
+  const folder = layout.folders[folderId]
+  if (!folder) return layout
+  const remaining = folder.items.filter(id => id !== itemId)
+  // Spill the removed item back onto the grid, right after the folder when it
+  // is placed, otherwise at the end (the folder may be self-healed and absent
+  // from order).
+  const folderIndex = layout.order.indexOf(folderId)
+  const order = [...layout.order]
+  if (folderIndex === -1) order.push(itemId)
+  else order.splice(folderIndex + 1, 0, itemId)
+
+  // A single remaining item is a valid folder (iOS-style); only drop the
+  // folder once it is empty.
+  if (remaining.length === 0) {
+    return {
+      order: order.filter(id => id !== folderId),
+      folders: omit(layout.folders, folderId)
+    }
+  }
+  return {
+    order,
+    folders: { ...layout.folders, [folderId]: { ...folder, items: remaining } }
+  }
+}
+
+export const reorderFolderItems = (
+  layout: HomeLayout,
+  folderId: string,
+  items: string[]
+): HomeLayout => {
+  const folder = layout.folders[folderId]
+  if (!folder) return layout
+  return {
+    ...layout,
+    folders: { ...layout.folders, [folderId]: { ...folder, items } }
+  }
+}
+
+export const dissolveFolder = (
+  layout: HomeLayout,
+  folderId: string
+): HomeLayout => {
+  const folder = layout.folders[folderId]
+  if (!folder) return layout
+  const order = layout.order.flatMap(id =>
+    id === folderId ? folder.items : [id]
+  )
+  return { order, folders: omit(layout.folders, folderId) }
+}
+
+export const renameFolder = (
+  layout: HomeLayout,
+  folderId: string,
+  name: string
+): HomeLayout => {
+  const folder = layout.folders[folderId]
+  if (!folder) return layout
+  return {
+    ...layout,
+    folders: { ...layout.folders, [folderId]: { ...folder, name } }
+  }
+}
+
+export const buildEntrypointItems = (
+  apps: IOCozyApp[] | null | undefined
+): EntrypointItem[] => {
+  if (!Array.isArray(apps)) return []
+  const drive = apps.find(a => a.slug === 'drive') as
+    | (IOCozyApp & { entrypoints?: Entrypoint[] })
+    | undefined
+  if (!drive) return []
+  const selected = selectEntrypoints(drive.entrypoints ?? [], [
+    'new-file-type-text',
+    'new-file-type-sheet',
+    'new-file-type-slide'
+  ]) as Entrypoint[]
+  const filtered = selected.filter(ep =>
+    (ep.conditions ?? []).every(c => {
+      if (c.type === 'flag' && c.name === 'bar.onlyoffice.enabled') return true
+      return checkEntrypointCondition(c)
+    })
+  )
+  return filtered.map(ep => ({
+    type: 'entrypoint',
+    id: makeEntrypointId(drive.slug, ep.name),
+    entrypoint: { ...ep, slug: drive.slug }
+  }))
+}

--- a/src/components/ApplicationsAndServices/index.spec.tsx
+++ b/src/components/ApplicationsAndServices/index.spec.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import flag from 'cozy-flags'
+
+import ApplicationsAndServicesEntry, { ApplicationsAndServices } from './index'
+import { useHomeLayout } from './useHomeLayout'
+
+import AppLike from '@/test/AppLike'
+
+jest.mock('cozy-flags', () => ({
+  __esModule: true,
+  default: jest.fn(() => false)
+}))
+jest.mock('./LegacyApplicationsAndServices', () => ({
+  __esModule: true,
+  default: (): JSX.Element => <div data-testid="legacy" />
+}))
+jest.mock('./useHomeLayout')
+jest.mock('@/components/AppTile', () => ({
+  __esModule: true,
+  default: ({ app }: { app: { slug: string } }): JSX.Element => (
+    <div data-testid="tile">{app.slug}</div>
+  )
+}))
+jest.mock('@/components/AppHighlightAlert/AppHighlightAlertWrapper', () => ({
+  __esModule: true,
+  default: (): null => null
+}))
+jest.mock('@/components/AddTile', () => ({
+  __esModule: true,
+  default: (): JSX.Element => <div data-testid="add-tile" />
+}))
+
+const appItem = (
+  slug: string
+): { type: string; id: string; app: { slug: string } } => ({
+  type: 'app',
+  id: `app:${slug}`,
+  app: { slug }
+})
+
+const setup = ({
+  items = [appItem('drive'), appItem('notes')],
+  layout = {
+    order: [] as string[],
+    folders: {} as Record<string, { name: string; items: string[] }>
+  },
+  hasLoaded = true,
+  isAppsLoading = false
+} = {}): void => {
+  ;(useHomeLayout as jest.Mock).mockReturnValue({
+    hasLoaded,
+    isAppsLoading,
+    items,
+    layout,
+    apps: [],
+    saveLayout: jest.fn()
+  })
+  render(
+    <AppLike>
+      <ApplicationsAndServices />
+    </AppLike>
+  )
+}
+
+describe('ApplicationsAndServices', () => {
+  it('renders tiles in default order', () => {
+    setup()
+    expect(screen.getAllByTestId('tile').map(t => t.textContent)).toEqual([
+      'drive',
+      'notes'
+    ])
+  })
+
+  it('renders a folder from the layout', () => {
+    setup({
+      items: [appItem('drive'), appItem('notes')],
+      layout: {
+        order: ['folder:a'],
+        folders: {
+          'folder:a': { name: 'G', items: ['app:drive', 'app:notes'] }
+        }
+      }
+    })
+    expect(screen.queryByTestId('folder-tile')).toBeInTheDocument()
+  })
+
+  it('shows loading tiles before load', () => {
+    setup({ hasLoaded: false })
+    expect(screen.queryByTestId('tile')).toBe(null)
+  })
+})
+
+describe('ApplicationsAndServices flag gating', () => {
+  beforeEach(() => {
+    ;(useHomeLayout as jest.Mock).mockReturnValue({
+      hasLoaded: true,
+      isAppsLoading: false,
+      items: [appItem('drive')],
+      layout: { order: [], folders: {} },
+      apps: [],
+      saveLayout: jest.fn()
+    })
+  })
+
+  it('renders the legacy list when the folders flag is off', () => {
+    ;(flag as unknown as jest.Mock).mockReturnValue(false)
+    render(
+      <AppLike>
+        <ApplicationsAndServicesEntry />
+      </AppLike>
+    )
+    expect(screen.getByTestId('legacy')).toBeInTheDocument()
+    expect(screen.queryByTestId('tile')).toBe(null)
+  })
+
+  it('renders the folders grid when the flag is on', () => {
+    ;(flag as unknown as jest.Mock).mockImplementation(
+      (name: string) => name === 'home.apps.folders'
+    )
+    render(
+      <AppLike>
+        <ApplicationsAndServicesEntry />
+      </AppLike>
+    )
+    expect(screen.getByTestId('tile')).toHaveTextContent('drive')
+    expect(screen.queryByTestId('legacy')).toBe(null)
+  })
+})

--- a/src/components/ApplicationsAndServices/index.tsx
+++ b/src/components/ApplicationsAndServices/index.tsx
@@ -1,6 +1,6 @@
 import { DndContext, DragOverlay, MeasuringStrategy } from '@dnd-kit/core'
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import flag from 'cozy-flags'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
@@ -10,13 +10,10 @@ import LegacyApplicationsAndServices from './LegacyApplicationsAndServices'
 import { SortableTile } from './SortableTile'
 import { TileContent } from './TileContent'
 import { noSortStrategy } from './dndGeometry'
-import {
-  dissolveFolder,
-  removeFromFolder,
-  renameFolder
-} from './homeLayout'
+import { dissolveFolder, removeFromFolder, renameFolder } from './homeLayout'
 import { LoadingAppTiles } from './types'
 import { useHomeDnd } from './useHomeDnd'
+import { useHomeLayout } from './useHomeLayout'
 
 import AddTile from '@/components/AddTile'
 import AppHighlightAlertWrapper from '@/components/AppHighlightAlert/AppHighlightAlertWrapper'
@@ -26,11 +23,17 @@ import LogoutTile from '@/components/LogoutTile'
 export const ApplicationsAndServices = (): JSX.Element => {
   const showLogout = Boolean(flag('home.mainlist.show-logout'))
   const { isMobile } = useBreakpoints()
+  const { hasLoaded, isAppsLoading, items, layout, apps, saveLayout } =
+    useHomeLayout()
+  const appsForAlerts = useMemo(
+    () =>
+      items
+        .filter(i => i.type === 'app')
+        .map(i => (i.type === 'app' ? i.app : null))
+        .filter(Boolean),
+    [items]
+  )
   const {
-    hasLoaded,
-    isAppsLoading,
-    apps,
-    appsForAlerts,
     grid,
     ids,
     combineTargetId,
@@ -45,7 +48,7 @@ export const ApplicationsAndServices = (): JSX.Element => {
     handleDragMove,
     handleDragCancel,
     handleDragEnd
-  } = useHomeDnd()
+  } = useHomeDnd({ items, layout, saveLayout })
 
   return (
     <div className="app-list-wrapper u-m-auto u-w-100">

--- a/src/components/ApplicationsAndServices/index.tsx
+++ b/src/components/ApplicationsAndServices/index.tsx
@@ -360,7 +360,7 @@ export const ApplicationsAndServices = (): JSX.Element => {
         onDragCancel={handleDragCancel}
         onDragEnd={handleDragEnd}
       >
-        <div className="home-grid app-list app-list--gutter u-w-100 u-mh-auto u-flex-justify-center">
+        <div className="app-list app-list--gutter u-pos-relative u-w-100 u-mh-auto u-flex-justify-center">
           {!hasLoaded || isAppsLoading ? (
             <LoadingAppTiles num={6} />
           ) : (

--- a/src/components/ApplicationsAndServices/index.tsx
+++ b/src/components/ApplicationsAndServices/index.tsx
@@ -45,15 +45,13 @@ import {
   renameFolder,
   reorderFolderItems
 } from './homeLayout'
+import { LoadingAppTiles } from './types'
 import { useHomeLayout } from './useHomeLayout'
 
 import AddTile from '@/components/AddTile'
 import AppHighlightAlertWrapper from '@/components/AppHighlightAlert/AppHighlightAlertWrapper'
-import { LoadingAppTiles as UntypedLoadingAppTiles } from '@/components/Applications'
 import AssistantTile from '@/components/AssistantTile'
 import LogoutTile from '@/components/LogoutTile'
-
-const LoadingAppTiles = UntypedLoadingAppTiles as React.FC<{ num: number }>
 
 // How long the dragged tile must hover (hold) over another tile before the
 // gesture is treated as "into the group": a regular tile folds into a new

--- a/src/components/ApplicationsAndServices/index.tsx
+++ b/src/components/ApplicationsAndServices/index.tsx
@@ -1,351 +1,51 @@
-import {
-  CollisionDetection,
-  DndContext,
-  DragEndEvent,
-  DragMoveEvent,
-  DragOverlay,
-  DragStartEvent,
-  KeyboardSensor,
-  MeasuringStrategy,
-  MouseSensor,
-  TouchSensor,
-  closestCenter,
-  pointerWithin,
-  useSensor,
-  useSensors
-} from '@dnd-kit/core'
-import {
-  SortableContext,
-  arrayMove,
-  rectSortingStrategy,
-  sortableKeyboardCoordinates
-} from '@dnd-kit/sortable'
-import React, { useMemo, useRef, useState } from 'react'
+import { DndContext, DragOverlay, MeasuringStrategy } from '@dnd-kit/core'
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
+import React from 'react'
 
 import flag from 'cozy-flags'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
-import { useI18n } from 'twake-i18n'
 
 import { FolderDialog } from './FolderDialog'
 import LegacyApplicationsAndServices from './LegacyApplicationsAndServices'
 import { SortableTile } from './SortableTile'
 import { TileContent } from './TileContent'
+import { noSortStrategy } from './dndGeometry'
 import {
-  FolderItem,
-  HomeLayout,
-  TileItem,
-  addToFolderAt,
-  buildGrid,
-  createFolderFromTile,
   dissolveFolder,
-  folderCategoryFromDoc,
-  isFolderId,
-  makeFolderId,
   removeFromFolder,
-  renameFolder,
-  reorderFolderItems
+  renameFolder
 } from './homeLayout'
 import { LoadingAppTiles } from './types'
-import { useHomeLayout } from './useHomeLayout'
+import { useHomeDnd } from './useHomeDnd'
 
 import AddTile from '@/components/AddTile'
 import AppHighlightAlertWrapper from '@/components/AppHighlightAlert/AppHighlightAlertWrapper'
 import AssistantTile from '@/components/AssistantTile'
 import LogoutTile from '@/components/LogoutTile'
 
-// How long the dragged tile must hover (hold) over another tile before the
-// gesture is treated as "into the group": a regular tile folds into a new
-// folder, a folder springs open so the icon can be dropped straight inside.
-const DWELL_MS = 450
-
-// No-op sorting strategy: keeps grid tiles in place during a drag. Live
-// shuffling would slide the hovered tile out from under the pointer, making a
-// stable "hold" gesture impossible. Grid reorder is committed on drop instead.
-const noSortStrategy = (): null => null
-
-// Fraction of each tile trimmed off every edge to form its central "group"
-// zone. The dragged tile's centre must sit inside this zone for a hold to fold
-// or spring a folder; elsewhere the drag just reorders.
-const CENTRAL_INSET = 0.25
-
-// True when the dragged tile's centre is inside the over tile's central zone.
-const isOverCentre = (active: DragMoveEvent['active'], over: DragMoveEvent['over']): boolean => {
-  const a = active.rect.current.translated
-  const r = over?.rect
-  if (!a || !r) return false
-  const cx = a.left + a.width / 2
-  const cy = a.top + a.height / 2
-  const ix = r.width * CENTRAL_INSET
-  const iy = r.height * CENTRAL_INSET
-  return (
-    cx >= r.left + ix && cx <= r.right - ix && cy >= r.top + iy && cy <= r.bottom - iy
-  )
-}
-
-// True when the dragged tile's centre is outside the open folder dialog.
-const isOutsideDialog = (active: DragEndEvent['active']): boolean => {
-  const a = active.rect.current.translated
-  const dialogEl = document.querySelector('[role="dialog"]')
-  if (!a || !dialogEl) return false
-  const r = dialogEl.getBoundingClientRect()
-  const cx = a.left + a.width / 2
-  const cy = a.top + a.height / 2
-  return cx < r.left || cx > r.right || cy < r.top || cy > r.bottom
-}
-
 export const ApplicationsAndServices = (): JSX.Element => {
-  const { t } = useI18n()
   const showLogout = Boolean(flag('home.mainlist.show-logout'))
   const { isMobile } = useBreakpoints()
-  const { hasLoaded, isAppsLoading, items, layout, apps, saveLayout } =
-    useHomeLayout()
-
-  const [activeId, setActiveId] = useState<string | null>(null)
-  // Tile/folder currently highlighted as the hold target (visual feedback).
-  const [combineTargetId, setCombineTargetId] = useState<string | null>(null)
-  // Pending "hold over a tile/folder" timer, armed on each over change.
-  const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Folder that sprang open during the current drag (so the drop lands inside).
-  const springFolderRef = useRef<string | null>(null)
-  // Tile whose central zone the dragged icon currently rests in (dwell target).
-  const centralTargetRef = useRef<string | null>(null)
-  // Whether the active item is being dragged from inside the open folder.
-  const dragSourceRef = useRef<'grid' | 'folder'>('grid')
-  const [openFolderId, setOpenFolderId] = useState<string | null>(null)
-  const [localLayout, setLocalLayout] = useState<HomeLayout | null>(null)
-  const dragLayoutRef = useRef<HomeLayout | null>(null)
-  const [lastLayout, setLastLayout] = useState(layout)
-
-  if (lastLayout !== layout) {
-    setLastLayout(layout)
-    setLocalLayout(null)
-  }
-
-  const effectiveLayout = localLayout ?? layout
-  const grid = useMemo(
-    () => buildGrid(effectiveLayout, items),
-    [effectiveLayout, items]
-  )
-  const ids = useMemo(() => grid.map(g => g.id), [grid])
-  const appsForAlerts = useMemo(
-    () =>
-      items
-        .filter(i => i.type === 'app')
-        .map(i => (i.type === 'app' ? i.app : null))
-        .filter(Boolean),
-    [items]
-  )
-
-  const openFolder = grid.find(
-    (g): g is FolderItem => g.id === openFolderId && g.type === 'folder'
-  )
-  const openFolderItemIds = openFolder ? openFolder.items.map(i => i.id) : null
-
-  // When a folder is open, only its inner tiles are drop targets: this lets a
-  // grid drag enter the open folder and a folder drag reorder/leave it.
-  const collisionDetection: CollisionDetection = args => {
-    if (openFolderItemIds) {
-      const set = new Set(openFolderItemIds)
-      const inDialog = args.droppableContainers.filter(c =>
-        set.has(String(c.id))
-      )
-      return pointerWithin({ ...args, droppableContainers: inDialog })
-    }
-    return closestCenter(args)
-  }
-
-  const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(TouchSensor, {
-      activationConstraint: { delay: 500, tolerance: 8 }
-    }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  )
-
-  const clearDwell = (): void => {
-    if (dwellTimerRef.current) {
-      clearTimeout(dwellTimerRef.current)
-      dwellTimerRef.current = null
-    }
-  }
-
-  // Default name for a folder created by dropping an item: the dropped app's
-  // (or konnector's) first manifest category, translated via the existing
-  // category.* keys. Falls back to the generic name when there is no usable
-  // category.
-  const folderNameForDragged = (itemId: string): string => {
-    const item = items.find(i => i.id === itemId)
-    const doc =
-      item?.type === 'app'
-        ? item.app
-        : item?.type === 'konnector'
-          ? item.konnector
-          : undefined
-    const category = folderCategoryFromDoc(doc)
-    if (category) {
-      const label = t(`category.${category}`)
-      if (label && !label.startsWith('category.')) return label
-    }
-    return t('folder.default_name')
-  }
-
-  const handleDragStart = ({ active }: DragStartEvent): void => {
-    const id = String(active.id)
-    setActiveId(id)
-    clearDwell()
-    setCombineTargetId(null)
-    springFolderRef.current = null
-    centralTargetRef.current = null
-    const fromFolder = Boolean(openFolder?.items.some(i => i.id === id))
-    dragSourceRef.current = fromFolder ? 'folder' : 'grid'
-    if (fromFolder) {
-      dragLayoutRef.current = effectiveLayout
-      return
-    }
-    // Materialise `order` from the full grid so reorder/insert always find
-    // every id (the saved order is sparse, often empty).
-    const normalized: HomeLayout = { ...effectiveLayout, order: ids }
-    dragLayoutRef.current = normalized
-    setLocalLayout(normalized)
-  }
-
-  // Siblings shuffle live (rectSortingStrategy) to preview a reorder. Holding
-  // the dragged icon over another tile's central zone instead starts a dwell:
-  // while the hold target is set the shuffle freezes (noSortStrategy) so the
-  // target stays put, and after DWELL_MS a group springs open around it.
-  const handleDragMove = ({ active, over }: DragMoveEvent): void => {
-    if (dragSourceRef.current === 'folder') return
-    if (springFolderRef.current) return // already inside a sprung-open folder
-    const id = String(active.id)
-    const overId = over ? String(over.id) : null
-    const central =
-      overId !== null &&
-      overId !== id &&
-      !isFolderId(id) &&
-      isOverCentre(active, over)
-
-    if (!central) {
-      if (centralTargetRef.current) {
-        centralTargetRef.current = null
-        clearDwell()
-        setCombineTargetId(null)
-      }
-      return
-    }
-    // Same central target as the last move: let the dwell timer keep running.
-    if (centralTargetRef.current === overId) return
-
-    centralTargetRef.current = overId
-    setCombineTargetId(overId) // highlight + freeze the shuffle
-    clearDwell()
-    const overIsFolder = isFolderId(overId)
-    dwellTimerRef.current = setTimeout(() => {
-      setCombineTargetId(null)
-      if (overIsFolder) {
-        springFolderRef.current = overId
-        setOpenFolderId(overId)
-        return
-      }
-      // Create a new folder around the held tile and spring it open.
-      const newFolderId = makeFolderId()
-      const next = createFolderFromTile(
-        dragLayoutRef.current ?? effectiveLayout,
-        overId,
-        newFolderId,
-        folderNameForDragged(id)
-      )
-      dragLayoutRef.current = next
-      springFolderRef.current = newFolderId
-      setLocalLayout(next)
-      setOpenFolderId(newFolderId)
-    }, DWELL_MS)
-  }
-
-  const handleDragCancel = (): void => {
-    setActiveId(null)
-    clearDwell()
-    setCombineTargetId(null)
-    centralTargetRef.current = null
-    if (springFolderRef.current) setOpenFolderId(null)
-    springFolderRef.current = null
-    dragLayoutRef.current = null
-    setLocalLayout(null)
-  }
-
-  const handleDragEnd = ({ active, over }: DragEndEvent): void => {
-    const draggedId = String(active.id)
-    const source = dragSourceRef.current
-    const spring = springFolderRef.current
-    const base = dragLayoutRef.current ?? effectiveLayout
-    const overId = over ? String(over.id) : null
-    setActiveId(null)
-    clearDwell()
-    setCombineTargetId(null)
-    centralTargetRef.current = null
-    springFolderRef.current = null
-
-    // 1) An item dragged from inside the open folder.
-    if (source === 'folder' && openFolder) {
-      const folderId = openFolder.id
-      const itemIds = openFolder.items.map(i => i.id)
-      if (isOutsideDialog(active)) {
-        handleSave(removeFromFolder(effectiveLayout, folderId, draggedId))
-        return
-      }
-      if (overId && overId !== draggedId) {
-        const from = itemIds.indexOf(draggedId)
-        const to = itemIds.indexOf(overId)
-        if (from !== -1 && to !== -1) {
-          handleSave(
-            reorderFolderItems(effectiveLayout, folderId, arrayMove(itemIds, from, to))
-          )
-        }
-      }
-      return
-    }
-
-    // 2) A grid item dropped into a folder that sprang open mid-drag (existing
-    // or just created around the held tile).
-    if (spring) {
-      if (!isOutsideDialog(active)) {
-        const folderItems = base.folders[spring]?.items ?? []
-        const idx = overId ? folderItems.indexOf(overId) : -1
-        const index = idx === -1 ? folderItems.length : idx
-        const next = addToFolderAt(base, spring, draggedId, index)
-        setLocalLayout(next)
-        saveLayout(next)
-        setOpenFolderId(spring)
-      } else {
-        // Pulled back out: cancel. Reverting localLayout drops a folder that was
-        // created mid-drag (never saved) and restores the dragged tile's slot.
-        setOpenFolderId(null)
-        setLocalLayout(null)
-      }
-      return
-    }
-
-    // 3) Plain grid reorder to wherever the live shuffle previewed.
-    if (overId && overId !== draggedId) {
-      const from = base.order.indexOf(draggedId)
-      const to = base.order.indexOf(overId)
-      if (from !== -1 && to !== -1) {
-        const next = { ...base, order: arrayMove(base.order, from, to) }
-        setLocalLayout(next)
-        saveLayout(next)
-        return
-      }
-    }
-    saveLayout(base)
-  }
-
-  const handleSave = (next: HomeLayout): void => {
-    setLocalLayout(next)
-    saveLayout(next)
-  }
-
-  const draggedItem: TileItem | FolderItem | undefined =
-    grid.find(g => g.id === activeId) ??
-    openFolder?.items.find(i => i.id === activeId)
+  const {
+    hasLoaded,
+    isAppsLoading,
+    apps,
+    appsForAlerts,
+    grid,
+    ids,
+    combineTargetId,
+    openFolder,
+    draggedItem,
+    effectiveLayout,
+    sensors,
+    collisionDetection,
+    setOpenFolderId,
+    handleSave,
+    handleDragStart,
+    handleDragMove,
+    handleDragCancel,
+    handleDragEnd
+  } = useHomeDnd()
 
   return (
     <div className="app-list-wrapper u-m-auto u-w-100">

--- a/src/components/ApplicationsAndServices/index.tsx
+++ b/src/components/ApplicationsAndServices/index.tsx
@@ -1,0 +1,427 @@
+import {
+  CollisionDetection,
+  DndContext,
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  MeasuringStrategy,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  pointerWithin,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates
+} from '@dnd-kit/sortable'
+import React, { useMemo, useRef, useState } from 'react'
+
+import flag from 'cozy-flags'
+import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
+import { useI18n } from 'twake-i18n'
+
+import { FolderDialog } from './FolderDialog'
+import LegacyApplicationsAndServices from './LegacyApplicationsAndServices'
+import { SortableTile } from './SortableTile'
+import { TileContent } from './TileContent'
+import {
+  FolderItem,
+  HomeLayout,
+  TileItem,
+  addToFolderAt,
+  buildGrid,
+  createFolderFromTile,
+  dissolveFolder,
+  folderCategoryFromDoc,
+  isFolderId,
+  makeFolderId,
+  removeFromFolder,
+  renameFolder,
+  reorderFolderItems
+} from './homeLayout'
+import { useHomeLayout } from './useHomeLayout'
+
+import AddTile from '@/components/AddTile'
+import AppHighlightAlertWrapper from '@/components/AppHighlightAlert/AppHighlightAlertWrapper'
+import { LoadingAppTiles as UntypedLoadingAppTiles } from '@/components/Applications'
+import AssistantTile from '@/components/AssistantTile'
+import LogoutTile from '@/components/LogoutTile'
+
+const LoadingAppTiles = UntypedLoadingAppTiles as React.FC<{ num: number }>
+
+// How long the dragged tile must hover (hold) over another tile before the
+// gesture is treated as "into the group": a regular tile folds into a new
+// folder, a folder springs open so the icon can be dropped straight inside.
+const DWELL_MS = 450
+
+// No-op sorting strategy: keeps grid tiles in place during a drag. Live
+// shuffling would slide the hovered tile out from under the pointer, making a
+// stable "hold" gesture impossible. Grid reorder is committed on drop instead.
+const noSortStrategy = (): null => null
+
+// Fraction of each tile trimmed off every edge to form its central "group"
+// zone. The dragged tile's centre must sit inside this zone for a hold to fold
+// or spring a folder; elsewhere the drag just reorders.
+const CENTRAL_INSET = 0.25
+
+// True when the dragged tile's centre is inside the over tile's central zone.
+const isOverCentre = (active: DragMoveEvent['active'], over: DragMoveEvent['over']): boolean => {
+  const a = active.rect.current.translated
+  const r = over?.rect
+  if (!a || !r) return false
+  const cx = a.left + a.width / 2
+  const cy = a.top + a.height / 2
+  const ix = r.width * CENTRAL_INSET
+  const iy = r.height * CENTRAL_INSET
+  return (
+    cx >= r.left + ix && cx <= r.right - ix && cy >= r.top + iy && cy <= r.bottom - iy
+  )
+}
+
+// True when the dragged tile's centre is outside the open folder dialog.
+const isOutsideDialog = (active: DragEndEvent['active']): boolean => {
+  const a = active.rect.current.translated
+  const dialogEl = document.querySelector('[role="dialog"]')
+  if (!a || !dialogEl) return false
+  const r = dialogEl.getBoundingClientRect()
+  const cx = a.left + a.width / 2
+  const cy = a.top + a.height / 2
+  return cx < r.left || cx > r.right || cy < r.top || cy > r.bottom
+}
+
+export const ApplicationsAndServices = (): JSX.Element => {
+  const { t } = useI18n()
+  const showLogout = Boolean(flag('home.mainlist.show-logout'))
+  const { isMobile } = useBreakpoints()
+  const { hasLoaded, isAppsLoading, items, layout, apps, saveLayout } =
+    useHomeLayout()
+
+  const [activeId, setActiveId] = useState<string | null>(null)
+  // Tile/folder currently highlighted as the hold target (visual feedback).
+  const [combineTargetId, setCombineTargetId] = useState<string | null>(null)
+  // Pending "hold over a tile/folder" timer, armed on each over change.
+  const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Folder that sprang open during the current drag (so the drop lands inside).
+  const springFolderRef = useRef<string | null>(null)
+  // Tile whose central zone the dragged icon currently rests in (dwell target).
+  const centralTargetRef = useRef<string | null>(null)
+  // Whether the active item is being dragged from inside the open folder.
+  const dragSourceRef = useRef<'grid' | 'folder'>('grid')
+  const [openFolderId, setOpenFolderId] = useState<string | null>(null)
+  const [localLayout, setLocalLayout] = useState<HomeLayout | null>(null)
+  const dragLayoutRef = useRef<HomeLayout | null>(null)
+  const [lastLayout, setLastLayout] = useState(layout)
+
+  if (lastLayout !== layout) {
+    setLastLayout(layout)
+    setLocalLayout(null)
+  }
+
+  const effectiveLayout = localLayout ?? layout
+  const grid = useMemo(
+    () => buildGrid(effectiveLayout, items),
+    [effectiveLayout, items]
+  )
+  const ids = useMemo(() => grid.map(g => g.id), [grid])
+  const appsForAlerts = useMemo(
+    () =>
+      items
+        .filter(i => i.type === 'app')
+        .map(i => (i.type === 'app' ? i.app : null))
+        .filter(Boolean),
+    [items]
+  )
+
+  const openFolder = grid.find(
+    (g): g is FolderItem => g.id === openFolderId && g.type === 'folder'
+  )
+  const openFolderItemIds = openFolder ? openFolder.items.map(i => i.id) : null
+
+  // When a folder is open, only its inner tiles are drop targets: this lets a
+  // grid drag enter the open folder and a folder drag reorder/leave it.
+  const collisionDetection: CollisionDetection = args => {
+    if (openFolderItemIds) {
+      const set = new Set(openFolderItemIds)
+      const inDialog = args.droppableContainers.filter(c =>
+        set.has(String(c.id))
+      )
+      return pointerWithin({ ...args, droppableContainers: inDialog })
+    }
+    return closestCenter(args)
+  }
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 500, tolerance: 8 }
+    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const clearDwell = (): void => {
+    if (dwellTimerRef.current) {
+      clearTimeout(dwellTimerRef.current)
+      dwellTimerRef.current = null
+    }
+  }
+
+  // Default name for a folder created by dropping an item: the dropped app's
+  // (or konnector's) first manifest category, translated via the existing
+  // category.* keys. Falls back to the generic name when there is no usable
+  // category.
+  const folderNameForDragged = (itemId: string): string => {
+    const item = items.find(i => i.id === itemId)
+    const doc =
+      item?.type === 'app'
+        ? item.app
+        : item?.type === 'konnector'
+          ? item.konnector
+          : undefined
+    const category = folderCategoryFromDoc(doc)
+    if (category) {
+      const label = t(`category.${category}`)
+      if (label && !label.startsWith('category.')) return label
+    }
+    return t('folder.default_name')
+  }
+
+  const handleDragStart = ({ active }: DragStartEvent): void => {
+    const id = String(active.id)
+    setActiveId(id)
+    clearDwell()
+    setCombineTargetId(null)
+    springFolderRef.current = null
+    centralTargetRef.current = null
+    const fromFolder = Boolean(openFolder?.items.some(i => i.id === id))
+    dragSourceRef.current = fromFolder ? 'folder' : 'grid'
+    if (fromFolder) {
+      dragLayoutRef.current = effectiveLayout
+      return
+    }
+    // Materialise `order` from the full grid so reorder/insert always find
+    // every id (the saved order is sparse, often empty).
+    const normalized: HomeLayout = { ...effectiveLayout, order: ids }
+    dragLayoutRef.current = normalized
+    setLocalLayout(normalized)
+  }
+
+  // Siblings shuffle live (rectSortingStrategy) to preview a reorder. Holding
+  // the dragged icon over another tile's central zone instead starts a dwell:
+  // while the hold target is set the shuffle freezes (noSortStrategy) so the
+  // target stays put, and after DWELL_MS a group springs open around it.
+  const handleDragMove = ({ active, over }: DragMoveEvent): void => {
+    if (dragSourceRef.current === 'folder') return
+    if (springFolderRef.current) return // already inside a sprung-open folder
+    const id = String(active.id)
+    const overId = over ? String(over.id) : null
+    const central =
+      overId !== null &&
+      overId !== id &&
+      !isFolderId(id) &&
+      isOverCentre(active, over)
+
+    if (!central) {
+      if (centralTargetRef.current) {
+        centralTargetRef.current = null
+        clearDwell()
+        setCombineTargetId(null)
+      }
+      return
+    }
+    // Same central target as the last move: let the dwell timer keep running.
+    if (centralTargetRef.current === overId) return
+
+    centralTargetRef.current = overId
+    setCombineTargetId(overId) // highlight + freeze the shuffle
+    clearDwell()
+    const overIsFolder = isFolderId(overId)
+    dwellTimerRef.current = setTimeout(() => {
+      setCombineTargetId(null)
+      if (overIsFolder) {
+        springFolderRef.current = overId
+        setOpenFolderId(overId)
+        return
+      }
+      // Create a new folder around the held tile and spring it open.
+      const newFolderId = makeFolderId()
+      const next = createFolderFromTile(
+        dragLayoutRef.current ?? effectiveLayout,
+        overId,
+        newFolderId,
+        folderNameForDragged(id)
+      )
+      dragLayoutRef.current = next
+      springFolderRef.current = newFolderId
+      setLocalLayout(next)
+      setOpenFolderId(newFolderId)
+    }, DWELL_MS)
+  }
+
+  const handleDragCancel = (): void => {
+    setActiveId(null)
+    clearDwell()
+    setCombineTargetId(null)
+    centralTargetRef.current = null
+    if (springFolderRef.current) setOpenFolderId(null)
+    springFolderRef.current = null
+    dragLayoutRef.current = null
+    setLocalLayout(null)
+  }
+
+  const handleDragEnd = ({ active, over }: DragEndEvent): void => {
+    const draggedId = String(active.id)
+    const source = dragSourceRef.current
+    const spring = springFolderRef.current
+    const base = dragLayoutRef.current ?? effectiveLayout
+    const overId = over ? String(over.id) : null
+    setActiveId(null)
+    clearDwell()
+    setCombineTargetId(null)
+    centralTargetRef.current = null
+    springFolderRef.current = null
+
+    // 1) An item dragged from inside the open folder.
+    if (source === 'folder' && openFolder) {
+      const folderId = openFolder.id
+      const itemIds = openFolder.items.map(i => i.id)
+      if (isOutsideDialog(active)) {
+        handleSave(removeFromFolder(effectiveLayout, folderId, draggedId))
+        return
+      }
+      if (overId && overId !== draggedId) {
+        const from = itemIds.indexOf(draggedId)
+        const to = itemIds.indexOf(overId)
+        if (from !== -1 && to !== -1) {
+          handleSave(
+            reorderFolderItems(effectiveLayout, folderId, arrayMove(itemIds, from, to))
+          )
+        }
+      }
+      return
+    }
+
+    // 2) A grid item dropped into a folder that sprang open mid-drag (existing
+    // or just created around the held tile).
+    if (spring) {
+      if (!isOutsideDialog(active)) {
+        const folderItems = base.folders[spring]?.items ?? []
+        const idx = overId ? folderItems.indexOf(overId) : -1
+        const index = idx === -1 ? folderItems.length : idx
+        const next = addToFolderAt(base, spring, draggedId, index)
+        setLocalLayout(next)
+        saveLayout(next)
+        setOpenFolderId(spring)
+      } else {
+        // Pulled back out: cancel. Reverting localLayout drops a folder that was
+        // created mid-drag (never saved) and restores the dragged tile's slot.
+        setOpenFolderId(null)
+        setLocalLayout(null)
+      }
+      return
+    }
+
+    // 3) Plain grid reorder to wherever the live shuffle previewed.
+    if (overId && overId !== draggedId) {
+      const from = base.order.indexOf(draggedId)
+      const to = base.order.indexOf(overId)
+      if (from !== -1 && to !== -1) {
+        const next = { ...base, order: arrayMove(base.order, from, to) }
+        setLocalLayout(next)
+        saveLayout(next)
+        return
+      }
+    }
+    saveLayout(base)
+  }
+
+  const handleSave = (next: HomeLayout): void => {
+    setLocalLayout(next)
+    saveLayout(next)
+  }
+
+  const draggedItem: TileItem | FolderItem | undefined =
+    grid.find(g => g.id === activeId) ??
+    openFolder?.items.find(i => i.id === activeId)
+
+  return (
+    <div className="app-list-wrapper u-m-auto u-w-100">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={collisionDetection}
+        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+        onDragStart={handleDragStart}
+        onDragMove={handleDragMove}
+        onDragCancel={handleDragCancel}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="home-grid app-list app-list--gutter u-w-100 u-mh-auto u-flex-justify-center">
+          {!hasLoaded || isAppsLoading ? (
+            <LoadingAppTiles num={6} />
+          ) : (
+            <SortableContext
+              items={ids}
+              strategy={combineTargetId ? noSortStrategy : rectSortingStrategy}
+            >
+              {grid.map(item => (
+                <SortableTile
+                  key={item.id}
+                  item={item}
+                  combineTarget={combineTargetId === item.id}
+                  onOpenFolder={setOpenFolderId}
+                />
+              ))}
+            </SortableContext>
+          )}
+          <AppHighlightAlertWrapper apps={appsForAlerts} />
+          {isMobile && Boolean(flag('cozy.assistant.enabled')) && (
+            <AssistantTile />
+          )}
+          <AddTile apps={apps} />
+          {showLogout && <LogoutTile />}
+        </div>
+
+        {openFolder && (
+          <FolderDialog
+            folder={openFolder}
+            onClose={() => setOpenFolderId(null)}
+            onRename={(id, name) =>
+              handleSave(renameFolder(effectiveLayout, id, name))
+            }
+            onDissolve={id => {
+              handleSave(dissolveFolder(effectiveLayout, id))
+              setOpenFolderId(null)
+            }}
+            onRemoveItem={(folderId, itemId) =>
+              handleSave(removeFromFolder(effectiveLayout, folderId, itemId))
+            }
+          />
+        )}
+
+        <DragOverlay zIndex={1401}>
+          {draggedItem ? (
+            <div className="home-drag-overlay">
+              <TileContent item={draggedItem} onOpenFolder={() => undefined} />
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  )
+}
+
+// Entry point: the folders grid is gated behind a flag so it can ship dark and
+// be enabled in production when ready. Off (default) keeps the legacy tile list.
+const ApplicationsAndServicesEntry = (): JSX.Element =>
+  flag('home.apps.folders') ? (
+    <ApplicationsAndServices />
+  ) : (
+    <LegacyApplicationsAndServices />
+  )
+
+export default ApplicationsAndServicesEntry

--- a/src/components/ApplicationsAndServices/types.ts
+++ b/src/components/ApplicationsAndServices/types.ts
@@ -14,8 +14,11 @@ import type {
   IOCozyFile,
   IOCozyKonnector
 } from 'cozy-client/types/types'
-import UntypedAppIcon from 'cozy-ui-plus/dist/AppIcon'
+import UntypedActionsMenu from 'cozy-ui/transpiled/react/ActionsMenu'
+import { makeActions as untypedMakeActions } from 'cozy-ui/transpiled/react/ActionsMenu/Actions'
+import { makeAction as untypedMakeAction } from 'cozy-ui/transpiled/react/ActionsMenu/Actions/makeAction'
 import UntypedTextField from 'cozy-ui/transpiled/react/TextField'
+import UntypedAppIcon from 'cozy-ui-plus/dist/AppIcon'
 
 import { LoadingAppTiles as UntypedLoadingAppTiles } from '@/components/Applications'
 
@@ -39,6 +42,30 @@ export const TextField = UntypedTextField as React.FC<{
 export const LoadingAppTiles = UntypedLoadingAppTiles as React.FC<{
   num: number
 }>
+
+export interface FolderAction {
+  name: string
+  icon: unknown
+  label: string
+  action: () => void
+}
+
+export const makeAction = untypedMakeAction as (a: FolderAction) => unknown
+
+export const makeActions = untypedMakeActions as unknown as (
+  actions: Array<() => unknown>,
+  options?: Record<string, unknown>
+) => unknown[]
+
+export const ActionsMenu =
+  UntypedActionsMenu as React.ForwardRefExoticComponent<
+    {
+      open: boolean
+      actions: unknown[]
+      anchorOrigin?: { vertical: string; horizontal: string }
+      onClose: () => void
+    } & React.RefAttributes<HTMLButtonElement>
+  >
 
 // --- Home layout domain types
 

--- a/src/components/ApplicationsAndServices/types.ts
+++ b/src/components/ApplicationsAndServices/types.ts
@@ -19,10 +19,6 @@ import UntypedTextField from 'cozy-ui/transpiled/react/TextField'
 
 import { LoadingAppTiles as UntypedLoadingAppTiles } from '@/components/Applications'
 
-const {
-  applications: { checkEntrypointCondition }
-} = models
-
 // --- Typed wrappers for cozy-ui(-plus) components that ship without usable TS
 // types, kept here so the casts are declared once instead of in every file.
 
@@ -46,7 +42,9 @@ export const LoadingAppTiles = UntypedLoadingAppTiles as React.FC<{
 
 // --- Home layout domain types
 
-export type EntrypointCondition = Parameters<typeof checkEntrypointCondition>[0]
+export type EntrypointCondition = Parameters<
+  typeof models.applications.checkEntrypointCondition
+>[0]
 
 export interface Entrypoint {
   name: string

--- a/src/components/ApplicationsAndServices/types.ts
+++ b/src/components/ApplicationsAndServices/types.ts
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import UntypedAppIcon from 'cozy-ui-plus/dist/AppIcon'
+import UntypedTextField from 'cozy-ui/transpiled/react/TextField'
+
+import { LoadingAppTiles as UntypedLoadingAppTiles } from '@/components/Applications'
+
+// Typed wrappers for cozy-ui(-plus) components that ship without usable TS
+// types, kept here so the casts are declared once instead of in every file.
+
+export const AppIcon = UntypedAppIcon as React.FC<{
+  app: unknown
+  type?: 'app' | 'konnector'
+  className?: string
+}>
+
+export const TextField = UntypedTextField as React.FC<{
+  value: string
+  placeholder: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onBlur: () => void
+  variant: string
+}>
+
+export const LoadingAppTiles = UntypedLoadingAppTiles as React.FC<{
+  num: number
+}>

--- a/src/components/ApplicationsAndServices/types.ts
+++ b/src/components/ApplicationsAndServices/types.ts
@@ -1,11 +1,29 @@
+import {
+  CollisionDetection,
+  DragEndEvent,
+  DragMoveEvent,
+  DragStartEvent,
+  SensorDescriptor,
+  SensorOptions
+} from '@dnd-kit/core'
 import React from 'react'
 
+import { models } from 'cozy-client'
+import type {
+  IOCozyApp,
+  IOCozyFile,
+  IOCozyKonnector
+} from 'cozy-client/types/types'
 import UntypedAppIcon from 'cozy-ui-plus/dist/AppIcon'
 import UntypedTextField from 'cozy-ui/transpiled/react/TextField'
 
 import { LoadingAppTiles as UntypedLoadingAppTiles } from '@/components/Applications'
 
-// Typed wrappers for cozy-ui(-plus) components that ship without usable TS
+const {
+  applications: { checkEntrypointCondition }
+} = models
+
+// --- Typed wrappers for cozy-ui(-plus) components that ship without usable TS
 // types, kept here so the casts are declared once instead of in every file.
 
 export const AppIcon = UntypedAppIcon as React.FC<{
@@ -25,3 +43,146 @@ export const TextField = UntypedTextField as React.FC<{
 export const LoadingAppTiles = UntypedLoadingAppTiles as React.FC<{
   num: number
 }>
+
+// --- Home layout domain types
+
+export type EntrypointCondition = Parameters<typeof checkEntrypointCondition>[0]
+
+export interface Entrypoint {
+  name: string
+  slug: string
+  hash: string
+  title: Record<string, string>
+  icon: string
+  conditions?: EntrypointCondition[]
+}
+
+export interface AppItem {
+  type: 'app'
+  id: string
+  app: IOCozyApp
+}
+
+export interface KonnectorItem {
+  type: 'konnector'
+  id: string
+  konnector: IOCozyKonnector
+  isInMaintenance: boolean
+  isRunning: boolean
+}
+
+export interface ShortcutItem {
+  type: 'shortcut'
+  id: string
+  file: IOCozyFile
+}
+
+export interface EntrypointItem {
+  type: 'entrypoint'
+  id: string
+  entrypoint: Entrypoint
+}
+
+export type TileItem = AppItem | KonnectorItem | ShortcutItem | EntrypointItem
+
+export interface FolderItem {
+  type: 'folder'
+  id: string
+  name: string
+  items: TileItem[]
+}
+
+export type GridItem = TileItem | FolderItem
+
+export interface FolderData {
+  name: string
+  items: string[]
+}
+
+export type FolderMap = Record<string, FolderData>
+
+export interface HomeLayout {
+  order: string[]
+  folders: FolderMap
+}
+
+export interface AppFilters {
+  sortSlugs: string[] | null
+  hiddenSlugs: string[]
+  hiddenHomeSlugs: string[]
+}
+
+// --- useHomeLayout hook
+
+export interface SettingsShape {
+  query: { fetchStatus: string; lastFetch?: number }
+  values?: { homeLayout?: HomeLayout }
+  save: (data: { homeLayout: HomeLayout }) => void
+}
+
+export interface UseHomeLayout {
+  hasLoaded: boolean
+  isAppsLoading: boolean
+  items: TileItem[]
+  layout: HomeLayout
+  apps: IOCozyApp[]
+  saveLayout: (layout: HomeLayout) => void
+}
+
+// --- Component props
+
+export interface SortableTileProps {
+  item: GridItem
+  combineTarget: boolean
+  onOpenFolder: (id: string) => void
+}
+
+export interface TileContentProps {
+  item: GridItem
+  onOpenFolder: (id: string) => void
+}
+
+export interface FolderTileProps {
+  folder: FolderItem
+  onOpen: (id: string) => void
+}
+
+export interface FolderDialogItemProps {
+  item: TileItem
+  onRemove: (itemId: string) => void
+  removeLabel: string
+}
+
+export interface FolderDialogProps {
+  folder: FolderItem
+  onClose: () => void
+  onRename: (id: string, name: string) => void
+  onDissolve: (id: string) => void
+  onRemoveItem: (folderId: string, itemId: string) => void
+}
+
+// --- useHomeDnd hook
+
+export interface UseHomeDndParams {
+  items: TileItem[]
+  layout: HomeLayout
+  saveLayout: (next: HomeLayout) => void
+}
+
+export interface UseHomeDndResult {
+  grid: GridItem[]
+  ids: string[]
+  activeId: string | null
+  combineTargetId: string | null
+  openFolder: FolderItem | undefined
+  draggedItem: TileItem | FolderItem | undefined
+  effectiveLayout: HomeLayout
+  sensors: SensorDescriptor<SensorOptions>[]
+  collisionDetection: CollisionDetection
+  setOpenFolderId: (id: string | null) => void
+  handleSave: (next: HomeLayout) => void
+  handleDragStart: (event: DragStartEvent) => void
+  handleDragMove: (event: DragMoveEvent) => void
+  handleDragCancel: () => void
+  handleDragEnd: (event: DragEndEvent) => void
+}

--- a/src/components/ApplicationsAndServices/useHomeDnd.ts
+++ b/src/components/ApplicationsAndServices/useHomeDnd.ts
@@ -1,0 +1,335 @@
+import {
+  CollisionDetection,
+  DragEndEvent,
+  DragMoveEvent,
+  DragStartEvent,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  pointerWithin,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { useMemo, useRef, useState } from 'react'
+
+import { useI18n } from 'twake-i18n'
+
+import { DWELL_MS, isOutsideDialog, isOverCentre } from './dndGeometry'
+import {
+  FolderItem,
+  HomeLayout,
+  TileItem,
+  addToFolderAt,
+  buildGrid,
+  createFolderFromTile,
+  folderCategoryFromDoc,
+  isFolderId,
+  makeFolderId,
+  removeFromFolder,
+  reorderFolderItems
+} from './homeLayout'
+import { useHomeLayout } from './useHomeLayout'
+
+// Owns the home grid drag-and-drop: reorder via live shuffle, hold-to-group,
+// spring-loaded folders and the open-folder dialog state. The component just
+// renders what this returns.
+export const useHomeDnd = (): {
+  hasLoaded: boolean
+  isAppsLoading: boolean
+  apps: ReturnType<typeof useHomeLayout>['apps']
+  appsForAlerts: unknown[]
+  grid: ReturnType<typeof buildGrid>
+  ids: string[]
+  activeId: string | null
+  combineTargetId: string | null
+  openFolder: FolderItem | undefined
+  draggedItem: TileItem | FolderItem | undefined
+  effectiveLayout: HomeLayout
+  sensors: ReturnType<typeof useSensors>
+  collisionDetection: CollisionDetection
+  setOpenFolderId: (id: string | null) => void
+  handleSave: (next: HomeLayout) => void
+  handleDragStart: (event: DragStartEvent) => void
+  handleDragMove: (event: DragMoveEvent) => void
+  handleDragCancel: () => void
+  handleDragEnd: (event: DragEndEvent) => void
+} => {
+  const { t } = useI18n()
+  const { hasLoaded, isAppsLoading, items, layout, apps, saveLayout } =
+    useHomeLayout()
+
+  const [activeId, setActiveId] = useState<string | null>(null)
+  // Tile/folder currently highlighted as the hold target (visual feedback).
+  const [combineTargetId, setCombineTargetId] = useState<string | null>(null)
+  // Pending "hold over a tile/folder" timer, armed on each over change.
+  const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Folder that sprang open during the current drag (so the drop lands inside).
+  const springFolderRef = useRef<string | null>(null)
+  // Tile whose central zone the dragged icon currently rests in (dwell target).
+  const centralTargetRef = useRef<string | null>(null)
+  // Whether the active item is being dragged from inside the open folder.
+  const dragSourceRef = useRef<'grid' | 'folder'>('grid')
+  const [openFolderId, setOpenFolderId] = useState<string | null>(null)
+  const [localLayout, setLocalLayout] = useState<HomeLayout | null>(null)
+  const dragLayoutRef = useRef<HomeLayout | null>(null)
+  const [lastLayout, setLastLayout] = useState(layout)
+
+  if (lastLayout !== layout) {
+    setLastLayout(layout)
+    setLocalLayout(null)
+  }
+
+  const effectiveLayout = localLayout ?? layout
+  const grid = useMemo(
+    () => buildGrid(effectiveLayout, items),
+    [effectiveLayout, items]
+  )
+  const ids = useMemo(() => grid.map(g => g.id), [grid])
+  const appsForAlerts = useMemo(
+    () =>
+      items
+        .filter(i => i.type === 'app')
+        .map(i => (i.type === 'app' ? i.app : null))
+        .filter(Boolean),
+    [items]
+  )
+
+  const openFolder = grid.find(
+    (g): g is FolderItem => g.id === openFolderId && g.type === 'folder'
+  )
+  const openFolderItemIds = openFolder ? openFolder.items.map(i => i.id) : null
+
+  // When a folder is open, only its inner tiles are drop targets: this lets a
+  // grid drag enter the open folder and a folder drag reorder/leave it.
+  const collisionDetection: CollisionDetection = args => {
+    if (openFolderItemIds) {
+      const set = new Set(openFolderItemIds)
+      const inDialog = args.droppableContainers.filter(c =>
+        set.has(String(c.id))
+      )
+      return pointerWithin({ ...args, droppableContainers: inDialog })
+    }
+    return closestCenter(args)
+  }
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 500, tolerance: 8 }
+    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const clearDwell = (): void => {
+    if (dwellTimerRef.current) {
+      clearTimeout(dwellTimerRef.current)
+      dwellTimerRef.current = null
+    }
+  }
+
+  const handleSave = (next: HomeLayout): void => {
+    setLocalLayout(next)
+    saveLayout(next)
+  }
+
+  // Default name for a folder created by dropping an item: the dropped app's
+  // (or konnector's) first manifest category, translated via the existing
+  // category.* keys. Falls back to the generic name when there is no usable
+  // category.
+  const folderNameForDragged = (itemId: string): string => {
+    const item = items.find(i => i.id === itemId)
+    const doc =
+      item?.type === 'app'
+        ? item.app
+        : item?.type === 'konnector'
+          ? item.konnector
+          : undefined
+    const category = folderCategoryFromDoc(doc)
+    if (category) {
+      const label = t(`category.${category}`)
+      if (label && !label.startsWith('category.')) return label
+    }
+    return t('folder.default_name')
+  }
+
+  const handleDragStart = ({ active }: DragStartEvent): void => {
+    const id = String(active.id)
+    setActiveId(id)
+    clearDwell()
+    setCombineTargetId(null)
+    springFolderRef.current = null
+    centralTargetRef.current = null
+    const fromFolder = Boolean(openFolder?.items.some(i => i.id === id))
+    dragSourceRef.current = fromFolder ? 'folder' : 'grid'
+    if (fromFolder) {
+      dragLayoutRef.current = effectiveLayout
+      return
+    }
+    // Materialise `order` from the full grid so reorder/insert always find
+    // every id (the saved order is sparse, often empty).
+    const normalized: HomeLayout = { ...effectiveLayout, order: ids }
+    dragLayoutRef.current = normalized
+    setLocalLayout(normalized)
+  }
+
+  // Siblings shuffle live (rectSortingStrategy) to preview a reorder. Holding
+  // the dragged icon over another tile's central zone instead starts a dwell:
+  // while the hold target is set the shuffle freezes (noSortStrategy) so the
+  // target stays put, and after DWELL_MS a group springs open around it.
+  const handleDragMove = ({ active, over }: DragMoveEvent): void => {
+    if (dragSourceRef.current === 'folder') return
+    if (springFolderRef.current) return // already inside a sprung-open folder
+    const id = String(active.id)
+    const overId = over ? String(over.id) : null
+    const central =
+      overId !== null &&
+      overId !== id &&
+      !isFolderId(id) &&
+      isOverCentre(active, over)
+
+    if (!central) {
+      if (centralTargetRef.current) {
+        centralTargetRef.current = null
+        clearDwell()
+        setCombineTargetId(null)
+      }
+      return
+    }
+    // Same central target as the last move: let the dwell timer keep running.
+    if (centralTargetRef.current === overId) return
+
+    centralTargetRef.current = overId
+    setCombineTargetId(overId) // highlight + freeze the shuffle
+    clearDwell()
+    const overIsFolder = isFolderId(overId)
+    dwellTimerRef.current = setTimeout(() => {
+      setCombineTargetId(null)
+      if (overIsFolder) {
+        springFolderRef.current = overId
+        setOpenFolderId(overId)
+        return
+      }
+      // Create a new folder around the held tile and spring it open.
+      const newFolderId = makeFolderId()
+      const next = createFolderFromTile(
+        dragLayoutRef.current ?? effectiveLayout,
+        overId,
+        newFolderId,
+        folderNameForDragged(id)
+      )
+      dragLayoutRef.current = next
+      springFolderRef.current = newFolderId
+      setLocalLayout(next)
+      setOpenFolderId(newFolderId)
+    }, DWELL_MS)
+  }
+
+  const handleDragCancel = (): void => {
+    setActiveId(null)
+    clearDwell()
+    setCombineTargetId(null)
+    centralTargetRef.current = null
+    if (springFolderRef.current) setOpenFolderId(null)
+    springFolderRef.current = null
+    dragLayoutRef.current = null
+    setLocalLayout(null)
+  }
+
+  const handleDragEnd = ({ active, over }: DragEndEvent): void => {
+    const draggedId = String(active.id)
+    const source = dragSourceRef.current
+    const spring = springFolderRef.current
+    const base = dragLayoutRef.current ?? effectiveLayout
+    const overId = over ? String(over.id) : null
+    setActiveId(null)
+    clearDwell()
+    setCombineTargetId(null)
+    centralTargetRef.current = null
+    springFolderRef.current = null
+
+    // 1) An item dragged from inside the open folder.
+    if (source === 'folder' && openFolder) {
+      const folderId = openFolder.id
+      const itemIds = openFolder.items.map(i => i.id)
+      if (isOutsideDialog(active)) {
+        handleSave(removeFromFolder(effectiveLayout, folderId, draggedId))
+        return
+      }
+      if (overId && overId !== draggedId) {
+        const from = itemIds.indexOf(draggedId)
+        const to = itemIds.indexOf(overId)
+        if (from !== -1 && to !== -1) {
+          handleSave(
+            reorderFolderItems(
+              effectiveLayout,
+              folderId,
+              arrayMove(itemIds, from, to)
+            )
+          )
+        }
+      }
+      return
+    }
+
+    // 2) A grid item dropped into a folder that sprang open mid-drag (existing
+    // or just created around the held tile).
+    if (spring) {
+      if (!isOutsideDialog(active)) {
+        const folderItems = base.folders[spring]?.items ?? []
+        const idx = overId ? folderItems.indexOf(overId) : -1
+        const index = idx === -1 ? folderItems.length : idx
+        const next = addToFolderAt(base, spring, draggedId, index)
+        setLocalLayout(next)
+        saveLayout(next)
+        setOpenFolderId(spring)
+      } else {
+        // Pulled back out: cancel. Reverting localLayout drops a folder that was
+        // created mid-drag (never saved) and restores the dragged tile's slot.
+        setOpenFolderId(null)
+        setLocalLayout(null)
+      }
+      return
+    }
+
+    // 3) Plain grid reorder to wherever the live shuffle previewed.
+    if (overId && overId !== draggedId) {
+      const from = base.order.indexOf(draggedId)
+      const to = base.order.indexOf(overId)
+      if (from !== -1 && to !== -1) {
+        const next = { ...base, order: arrayMove(base.order, from, to) }
+        setLocalLayout(next)
+        saveLayout(next)
+        return
+      }
+    }
+    saveLayout(base)
+  }
+
+  const draggedItem: TileItem | FolderItem | undefined =
+    grid.find(g => g.id === activeId) ??
+    openFolder?.items.find(i => i.id === activeId)
+
+  return {
+    hasLoaded,
+    isAppsLoading,
+    apps,
+    appsForAlerts,
+    grid,
+    ids,
+    activeId,
+    combineTargetId,
+    openFolder,
+    draggedItem,
+    effectiveLayout,
+    sensors,
+    collisionDetection,
+    setOpenFolderId,
+    handleSave,
+    handleDragStart,
+    handleDragMove,
+    handleDragCancel,
+    handleDragEnd
+  }
+}

--- a/src/components/ApplicationsAndServices/useHomeDnd.ts
+++ b/src/components/ApplicationsAndServices/useHomeDnd.ts
@@ -18,9 +18,6 @@ import { useI18n } from 'twake-i18n'
 
 import { DWELL_MS, isOutsideDialog, isOverCentre } from './dndGeometry'
 import {
-  FolderItem,
-  HomeLayout,
-  TileItem,
   addToFolder,
   buildGrid,
   createFolder,
@@ -30,12 +27,13 @@ import {
   removeFromFolder,
   reorderFolderItems
 } from './homeLayout'
-
-interface UseHomeDndParams {
-  items: TileItem[]
-  layout: HomeLayout
-  saveLayout: (next: HomeLayout) => void
-}
+import {
+  FolderItem,
+  HomeLayout,
+  TileItem,
+  UseHomeDndParams,
+  UseHomeDndResult
+} from './types'
 
 // Owns the home grid drag-and-drop only: reorder via live shuffle, hold-to-group
 // (the icon is dropped into the folder, which opens for repositioning) and the
@@ -44,23 +42,7 @@ export const useHomeDnd = ({
   items,
   layout,
   saveLayout
-}: UseHomeDndParams): {
-  grid: ReturnType<typeof buildGrid>
-  ids: string[]
-  activeId: string | null
-  combineTargetId: string | null
-  openFolder: FolderItem | undefined
-  draggedItem: TileItem | FolderItem | undefined
-  effectiveLayout: HomeLayout
-  sensors: ReturnType<typeof useSensors>
-  collisionDetection: CollisionDetection
-  setOpenFolderId: (id: string | null) => void
-  handleSave: (next: HomeLayout) => void
-  handleDragStart: (event: DragStartEvent) => void
-  handleDragMove: (event: DragMoveEvent) => void
-  handleDragCancel: () => void
-  handleDragEnd: (event: DragEndEvent) => void
-} => {
+}: UseHomeDndParams): UseHomeDndResult => {
   const { t } = useI18n()
 
   const [activeId, setActiveId] = useState<string | null>(null)

--- a/src/components/ApplicationsAndServices/useHomeDnd.ts
+++ b/src/components/ApplicationsAndServices/useHomeDnd.ts
@@ -21,9 +21,9 @@ import {
   FolderItem,
   HomeLayout,
   TileItem,
-  addToFolderAt,
+  addToFolder,
   buildGrid,
-  createFolderFromTile,
+  createFolder,
   folderCategoryFromDoc,
   isFolderId,
   makeFolderId,
@@ -32,9 +32,9 @@ import {
 } from './homeLayout'
 import { useHomeLayout } from './useHomeLayout'
 
-// Owns the home grid drag-and-drop: reorder via live shuffle, hold-to-group,
-// spring-loaded folders and the open-folder dialog state. The component just
-// renders what this returns.
+// Owns the home grid drag-and-drop: reorder via live shuffle, hold-to-group
+// (the icon is dropped into the folder, which opens for repositioning) and the
+// open-folder dialog state. The component just renders what this returns.
 export const useHomeDnd = (): {
   hasLoaded: boolean
   isAppsLoading: boolean
@@ -65,8 +65,9 @@ export const useHomeDnd = (): {
   const [combineTargetId, setCombineTargetId] = useState<string | null>(null)
   // Pending "hold over a tile/folder" timer, armed on each over change.
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Folder that sprang open during the current drag (so the drop lands inside).
-  const springFolderRef = useRef<string | null>(null)
+  // Set once the dragged icon has been dropped into a folder on dwell, so the
+  // rest of the gesture (moves, drop) is ignored.
+  const committedRef = useRef(false)
   // Tile whose central zone the dragged icon currently rests in (dwell target).
   const centralTargetRef = useRef<string | null>(null)
   // Whether the active item is being dragged from inside the open folder.
@@ -159,7 +160,7 @@ export const useHomeDnd = (): {
     setActiveId(id)
     clearDwell()
     setCombineTargetId(null)
-    springFolderRef.current = null
+    committedRef.current = false
     centralTargetRef.current = null
     const fromFolder = Boolean(openFolder?.items.some(i => i.id === id))
     dragSourceRef.current = fromFolder ? 'folder' : 'grid'
@@ -176,11 +177,12 @@ export const useHomeDnd = (): {
 
   // Siblings shuffle live (rectSortingStrategy) to preview a reorder. Holding
   // the dragged icon over another tile's central zone instead starts a dwell:
-  // while the hold target is set the shuffle freezes (noSortStrategy) so the
-  // target stays put, and after DWELL_MS a group springs open around it.
+  // while the hold target is set the shuffle freezes (noSortStrategy). When the
+  // dwell completes the icon is dropped straight into the group (existing folder
+  // or a new one around the held tile), which opens for repositioning.
   const handleDragMove = ({ active, over }: DragMoveEvent): void => {
     if (dragSourceRef.current === 'folder') return
-    if (springFolderRef.current) return // already inside a sprung-open folder
+    if (committedRef.current) return // already dropped into a folder
     const id = String(active.id)
     const overId = over ? String(over.id) : null
     const central =
@@ -205,24 +207,29 @@ export const useHomeDnd = (): {
     clearDwell()
     const overIsFolder = isFolderId(overId)
     dwellTimerRef.current = setTimeout(() => {
-      setCombineTargetId(null)
+      const baseLayout = dragLayoutRef.current ?? effectiveLayout
+      let next: HomeLayout
+      let folderToOpen: string
       if (overIsFolder) {
-        springFolderRef.current = overId
-        setOpenFolderId(overId)
-        return
+        next = addToFolder(baseLayout, overId, id)
+        folderToOpen = overId
+      } else {
+        folderToOpen = makeFolderId()
+        next = createFolder(
+          baseLayout,
+          overId,
+          id,
+          () => folderToOpen,
+          folderNameForDragged(id)
+        )
       }
-      // Create a new folder around the held tile and spring it open.
-      const newFolderId = makeFolderId()
-      const next = createFolderFromTile(
-        dragLayoutRef.current ?? effectiveLayout,
-        overId,
-        newFolderId,
-        folderNameForDragged(id)
-      )
+      committedRef.current = true
       dragLayoutRef.current = next
-      springFolderRef.current = newFolderId
       setLocalLayout(next)
-      setOpenFolderId(newFolderId)
+      saveLayout(next)
+      setOpenFolderId(folderToOpen)
+      setCombineTargetId(null)
+      setActiveId(null) // hide the drag overlay: the icon is now dropped inside
     }, DWELL_MS)
   }
 
@@ -231,8 +238,7 @@ export const useHomeDnd = (): {
     clearDwell()
     setCombineTargetId(null)
     centralTargetRef.current = null
-    if (springFolderRef.current) setOpenFolderId(null)
-    springFolderRef.current = null
+    committedRef.current = false
     dragLayoutRef.current = null
     setLocalLayout(null)
   }
@@ -240,14 +246,18 @@ export const useHomeDnd = (): {
   const handleDragEnd = ({ active, over }: DragEndEvent): void => {
     const draggedId = String(active.id)
     const source = dragSourceRef.current
-    const spring = springFolderRef.current
     const base = dragLayoutRef.current ?? effectiveLayout
     const overId = over ? String(over.id) : null
     setActiveId(null)
     clearDwell()
     setCombineTargetId(null)
     centralTargetRef.current = null
-    springFolderRef.current = null
+
+    // Already dropped into a folder on dwell: nothing more to do.
+    if (committedRef.current) {
+      committedRef.current = false
+      return
+    }
 
     // 1) An item dragged from inside the open folder.
     if (source === 'folder' && openFolder) {
@@ -273,27 +283,7 @@ export const useHomeDnd = (): {
       return
     }
 
-    // 2) A grid item dropped into a folder that sprang open mid-drag (existing
-    // or just created around the held tile).
-    if (spring) {
-      if (!isOutsideDialog(active)) {
-        const folderItems = base.folders[spring]?.items ?? []
-        const idx = overId ? folderItems.indexOf(overId) : -1
-        const index = idx === -1 ? folderItems.length : idx
-        const next = addToFolderAt(base, spring, draggedId, index)
-        setLocalLayout(next)
-        saveLayout(next)
-        setOpenFolderId(spring)
-      } else {
-        // Pulled back out: cancel. Reverting localLayout drops a folder that was
-        // created mid-drag (never saved) and restores the dragged tile's slot.
-        setOpenFolderId(null)
-        setLocalLayout(null)
-      }
-      return
-    }
-
-    // 3) Plain grid reorder to wherever the live shuffle previewed.
+    // 2) Plain grid reorder to wherever the live shuffle previewed.
     if (overId && overId !== draggedId) {
       const from = base.order.indexOf(draggedId)
       const to = base.order.indexOf(overId)

--- a/src/components/ApplicationsAndServices/useHomeDnd.ts
+++ b/src/components/ApplicationsAndServices/useHomeDnd.ts
@@ -30,16 +30,21 @@ import {
   removeFromFolder,
   reorderFolderItems
 } from './homeLayout'
-import { useHomeLayout } from './useHomeLayout'
 
-// Owns the home grid drag-and-drop: reorder via live shuffle, hold-to-group
+interface UseHomeDndParams {
+  items: TileItem[]
+  layout: HomeLayout
+  saveLayout: (next: HomeLayout) => void
+}
+
+// Owns the home grid drag-and-drop only: reorder via live shuffle, hold-to-group
 // (the icon is dropped into the folder, which opens for repositioning) and the
-// open-folder dialog state. The component just renders what this returns.
-export const useHomeDnd = (): {
-  hasLoaded: boolean
-  isAppsLoading: boolean
-  apps: ReturnType<typeof useHomeLayout>['apps']
-  appsForAlerts: unknown[]
+// open-folder dialog state. Data loading stays in useHomeLayout, in the caller.
+export const useHomeDnd = ({
+  items,
+  layout,
+  saveLayout
+}: UseHomeDndParams): {
   grid: ReturnType<typeof buildGrid>
   ids: string[]
   activeId: string | null
@@ -57,8 +62,6 @@ export const useHomeDnd = (): {
   handleDragEnd: (event: DragEndEvent) => void
 } => {
   const { t } = useI18n()
-  const { hasLoaded, isAppsLoading, items, layout, apps, saveLayout } =
-    useHomeLayout()
 
   const [activeId, setActiveId] = useState<string | null>(null)
   // Tile/folder currently highlighted as the hold target (visual feedback).
@@ -88,14 +91,6 @@ export const useHomeDnd = (): {
     [effectiveLayout, items]
   )
   const ids = useMemo(() => grid.map(g => g.id), [grid])
-  const appsForAlerts = useMemo(
-    () =>
-      items
-        .filter(i => i.type === 'app')
-        .map(i => (i.type === 'app' ? i.app : null))
-        .filter(Boolean),
-    [items]
-  )
 
   const openFolder = grid.find(
     (g): g is FolderItem => g.id === openFolderId && g.type === 'folder'
@@ -302,10 +297,6 @@ export const useHomeDnd = (): {
     openFolder?.items.find(i => i.id === activeId)
 
   return {
-    hasLoaded,
-    isAppsLoading,
-    apps,
-    appsForAlerts,
     grid,
     ids,
     activeId,

--- a/src/components/ApplicationsAndServices/useHomeLayout.spec.ts
+++ b/src/components/ApplicationsAndServices/useHomeLayout.spec.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react'
+
+import { useSettings } from 'cozy-client'
+
+import { useHomeLayout } from './useHomeLayout'
+
+jest.mock('cozy-client', () => ({
+  ...jest.requireActual('cozy-client'),
+  useSettings: jest.fn(),
+  useQuery: (): { data: never[]; fetchStatus: string } => ({
+    data: [],
+    fetchStatus: 'loaded'
+  }),
+  useFetchHomeShortcuts: (): never[] => [],
+  useAppsInMaintenance: (): never[] => []
+}))
+jest.mock('react-redux', () => ({ useSelector: (): never[] => [] }))
+jest.mock('@/lib/konnectors_typed', () => ({
+  fetchRunningKonnectors: { definition: {}, options: {} },
+  getRunningKonnectors: (): never[] => []
+}))
+
+describe('useHomeLayout', () => {
+  it('reads layout and saves through useSettings', () => {
+    const save = jest.fn()
+    ;(useSettings as jest.Mock).mockReturnValue({
+      query: { fetchStatus: 'loaded' },
+      values: { homeLayout: { order: ['app:drive'], folders: {} } },
+      save
+    })
+    const { result } = renderHook(() => useHomeLayout())
+    expect(result.current.layout).toEqual({ order: ['app:drive'], folders: {} })
+    result.current.saveLayout({ order: ['app:notes'], folders: {} })
+    expect(save).toHaveBeenCalledWith({
+      homeLayout: { order: ['app:notes'], folders: {} }
+    })
+  })
+
+  it('falls back to an empty layout', () => {
+    ;(useSettings as jest.Mock).mockReturnValue({
+      query: { fetchStatus: 'loaded' },
+      values: {},
+      save: jest.fn()
+    })
+    const { result } = renderHook(() => useHomeLayout())
+    expect(result.current.layout).toEqual({ order: [], folders: {} })
+  })
+})

--- a/src/components/ApplicationsAndServices/useHomeLayout.ts
+++ b/src/components/ApplicationsAndServices/useHomeLayout.ts
@@ -11,13 +11,17 @@ import type { IOCozyApp, IOCozyKonnector } from 'cozy-client/types/types'
 import flag from 'cozy-flags'
 
 import {
-  HomeLayout,
-  TileItem,
   buildAppItems,
   buildEntrypointItems,
   buildKonnectorItems,
   buildShortcutItems
 } from './homeLayout'
+import type {
+  HomeLayout,
+  SettingsShape,
+  TileItem,
+  UseHomeLayout
+} from './types'
 
 import {
   fetchRunningKonnectors,
@@ -31,21 +35,6 @@ const toArray = (v: unknown): string[] =>
   Array.isArray(v) ? (v as string[]) : []
 const toArrayOrNull = (v: unknown): string[] | null =>
   Array.isArray(v) ? (v as string[]) : null
-
-interface SettingsShape {
-  query: { fetchStatus: string; lastFetch?: number }
-  values?: { homeLayout?: HomeLayout }
-  save: (data: { homeLayout: HomeLayout }) => void
-}
-
-export interface UseHomeLayout {
-  hasLoaded: boolean
-  isAppsLoading: boolean
-  items: TileItem[]
-  layout: HomeLayout
-  apps: IOCozyApp[]
-  saveLayout: (layout: HomeLayout) => void
-}
 
 export const useHomeLayout = (): UseHomeLayout => {
   const { data: apps } = useQuery(appsConn.query, appsConn) as {

--- a/src/components/ApplicationsAndServices/useHomeLayout.ts
+++ b/src/components/ApplicationsAndServices/useHomeLayout.ts
@@ -1,0 +1,108 @@
+import keyBy from 'lodash/keyBy'
+import sortBy from 'lodash/sortBy'
+import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+
+import {
+  useAppsInMaintenance,
+  useFetchHomeShortcuts,
+  useQuery,
+  useSettings
+} from 'cozy-client'
+import type { IOCozyApp, IOCozyKonnector } from 'cozy-client/types/types'
+import flag from 'cozy-flags'
+
+import {
+  HomeLayout,
+  TileItem,
+  buildAppItems,
+  buildEntrypointItems,
+  buildKonnectorItems,
+  buildShortcutItems
+} from './homeLayout'
+
+import {
+  fetchRunningKonnectors,
+  getRunningKonnectors
+} from '@/lib/konnectors_typed'
+import { appsConn } from '@/queries'
+import { getInstalledKonnectors } from '@/selectors/konnectors'
+
+const EMPTY_LAYOUT: HomeLayout = { order: [], folders: {} }
+const toArray = (v: unknown): string[] =>
+  Array.isArray(v) ? (v as string[]) : []
+const toArrayOrNull = (v: unknown): string[] | null =>
+  Array.isArray(v) ? (v as string[]) : null
+
+interface SettingsShape {
+  query: { fetchStatus: string; lastFetch?: number }
+  values?: { homeLayout?: HomeLayout }
+  save: (data: { homeLayout: HomeLayout }) => void
+}
+
+export interface UseHomeLayout {
+  hasLoaded: boolean
+  isAppsLoading: boolean
+  items: TileItem[]
+  layout: HomeLayout
+  apps: IOCozyApp[]
+  saveLayout: (layout: HomeLayout) => void
+}
+
+export const useHomeLayout = (): UseHomeLayout => {
+  const { data: apps } = useQuery(appsConn.query, appsConn) as {
+    data: IOCozyApp[] | null
+  }
+  const shortcuts = useFetchHomeShortcuts() as
+    | Parameters<typeof buildShortcutItems>[0]
+    | null
+  const maintenance = useAppsInMaintenance() as unknown as IOCozyKonnector[]
+  const installedKonnectors = useSelector(getInstalledKonnectors) as
+    | IOCozyKonnector[]
+    | null
+  const { data: jobData } = useQuery(
+    fetchRunningKonnectors.definition,
+    fetchRunningKonnectors.options
+  )
+
+  const { query, values, save } = useSettings('home', [
+    'homeLayout'
+  ]) as unknown as SettingsShape
+  const layout = values?.homeLayout ?? EMPTY_LAYOUT
+
+  const sortSlugs = toArrayOrNull(flag('apps.sort'))
+  const hiddenSlugs = toArray(flag('apps.hidden'))
+  const hiddenHomeSlugs = toArray(flag('apps.hidden-in-home'))
+
+  const items = useMemo(
+    (): TileItem[] => [
+      ...buildAppItems(apps, { sortSlugs, hiddenSlugs, hiddenHomeSlugs }),
+      ...buildKonnectorItems(
+        sortBy(installedKonnectors ?? [], k => k.name.toLowerCase()),
+        new Set(Object.keys(keyBy(maintenance, 'slug'))),
+        getRunningKonnectors(jobData)
+      ),
+      ...buildShortcutItems(shortcuts),
+      ...buildEntrypointItems(apps)
+    ],
+    [
+      apps,
+      shortcuts,
+      maintenance,
+      installedKonnectors,
+      jobData,
+      sortSlugs,
+      hiddenSlugs,
+      hiddenHomeSlugs
+    ]
+  )
+
+  return {
+    hasLoaded: query.fetchStatus === 'loaded' || Boolean(query.lastFetch),
+    isAppsLoading: !Array.isArray(apps),
+    items,
+    layout,
+    apps: apps ?? [],
+    saveLayout: next => save({ homeLayout: next })
+  }
+}

--- a/src/components/ApplicationsAndServices/useHomeLayout.ts
+++ b/src/components/ApplicationsAndServices/useHomeLayout.ts
@@ -1,5 +1,3 @@
-import keyBy from 'lodash/keyBy'
-import sortBy from 'lodash/sortBy'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
@@ -78,8 +76,10 @@ export const useHomeLayout = (): UseHomeLayout => {
     (): TileItem[] => [
       ...buildAppItems(apps, { sortSlugs, hiddenSlugs, hiddenHomeSlugs }),
       ...buildKonnectorItems(
-        sortBy(installedKonnectors ?? [], k => k.name.toLowerCase()),
-        new Set(Object.keys(keyBy(maintenance, 'slug'))),
+        [...(installedKonnectors ?? [])].sort((a, b) =>
+          a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+        ),
+        new Set(maintenance.map(k => k.slug)),
         getRunningKonnectors(jobData)
       ),
       ...buildShortcutItems(shortcuts),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -540,7 +540,8 @@
     "default_name": "Folder",
     "name_placeholder": "Folder name",
     "dissolve": "Dissolve the folder",
-    "remove_item": "Remove from folder"
+    "remove_item": "Remove from folder",
+    "actions": "Folder actions"
   },
   "Queue": {
     "header": "Syncing accounts:",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -536,6 +536,12 @@
     "edit": "Modify shortcut",
     "delete": "Delete"
   },
+  "folder": {
+    "default_name": "Folder",
+    "name_placeholder": "Folder name",
+    "dissolve": "Dissolve the folder",
+    "remove_item": "Remove from folder"
+  },
   "Queue": {
     "header": "Syncing accounts:",
     "header_mobile": "%{done} of %{total}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -537,6 +537,12 @@
     "edit": "Modifier le raccourci",
     "delete": "Supprimer"
   },
+  "folder": {
+    "default_name": "Dossier",
+    "name_placeholder": "Nom du dossier",
+    "dissolve": "Dissoudre le dossier",
+    "remove_item": "Retirer du dossier"
+  },
   "Queue": {
     "header": "Synchronisation :",
     "header_mobile": "%{done} sur %{total}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -541,7 +541,8 @@
     "default_name": "Dossier",
     "name_placeholder": "Nom du dossier",
     "dissolve": "Dissoudre le dossier",
-    "remove_item": "Retirer du dossier"
+    "remove_item": "Retirer du dossier",
+    "actions": "Actions du dossier"
   },
   "Queue": {
     "header": "Synchronisation :",

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -142,9 +142,6 @@ div[class*='SquareAppIcon-icon-container'] .section-app-group
     min-width 14px
 
 // Home folders / drag & drop
-.home-grid
-    position relative
-
 .home-item
     touch-action manipulation
 

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -192,7 +192,7 @@ div[class*='SquareAppIcon-icon-container'] .section-app-group
 .home-folder-content
     display flex
     flex-wrap wrap
-    justify-content center
+    justify-content flex-start
     padding rem(14) 0 rem(4)
     min-width rem(248)
 

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -140,3 +140,96 @@ div[class*='SquareAppIcon-icon-container'] .section-app-group
     width 100%
     align-items center
     min-width 14px
+
+// Home folders / drag & drop
+.home-grid
+    position relative
+
+.home-item
+    touch-action manipulation
+
+    &--placeholder
+        opacity .25
+        pointer-events none
+
+    // Highlights a tile that will receive a folder-drop
+    &--combine
+        box-shadow inset 0 0 0 2px var(--primaryColor)
+        border-radius rem(8)
+
+.home-folder-tile
+    width 100%
+    padding 0
+    border 0
+    background none
+    color inherit
+    font inherit
+    cursor pointer
+
+.home-folder-preview
+    display grid
+    grid-template-columns repeat(2, 1fr)
+    grid-template-rows repeat(2, 1fr)
+    grid-gap rem(2)
+    width rem(32)
+    height rem(32)
+
+.home-folder-preview-cell
+    display flex
+    overflow hidden
+    align-items center
+    justify-content center
+    border-radius rem(3)
+
+    // Beats cozy-ui-plus .c-app-icon sizing so every item fills its cell
+    // (the cell already clips to rounded corners via overflow + border-radius)
+    .home-folder-preview-img
+        display block
+        width 100%
+        height 100%
+        object-fit cover
+
+.home-drag-overlay
+    cursor grabbing
+
+.home-folder-content
+    display flex
+    flex-wrap wrap
+    justify-content center
+    padding rem(14) 0 rem(4)
+    min-width rem(248)
+
+.home-folder-item
+    position relative
+
+    &--dragging
+        opacity .3
+
+    // App names should not look like links inside the folder dialog
+    a
+        text-decoration none
+
+    // Nested so the compound selector beats MUI .MuiIconButton-root while the
+    // cross overlays the icon's top-right corner; only shown on hover (below).
+    .home-folder-remove
+        position absolute
+        z-index 2
+        top rem(-6)
+        left 'calc(50% + %s)' % rem(13)
+        padding rem(2)
+        color var(--secondaryTextColor)
+        opacity 0
+        transition opacity 120ms ease
+
+        &:hover
+            color var(--primaryTextColor)
+
+.home-folder-item-icon
+    cursor grab
+    touch-action manipulation
+
+// Shown only when the tile is hovered; the paper background keeps it readable
+// over an icon and overrides the MUI IconButton hover tint.
+.home-folder-item:hover .home-folder-remove
+    opacity 1
+    background var(--paperBackgroundColor)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,37 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emnapi/core@^1.4.3":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
@@ -14798,7 +14829,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14832,15 +14863,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15019,7 +15041,7 @@ stringify-object@^3.2.2:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15046,13 +15068,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16435,7 +16450,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16459,15 +16474,6 @@ wrap-ansi@^3.0.1:
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
## Summary
- flag('home.apps.folders') 
- Drag an icon onto another and hold to group them: the folder springs open during the drag so the icon can be dropped straight inside at a chosen position.
- Drag icons to reorder, with the surrounding tiles shuffling live to preview where the icon will land.
- Open a folder in a dialog to rename it, reorder its items, remove an item (or drag it out back onto the grid), and dissolve it.
- A new folder takes the dropped app's manifest category as its default name; closed folders show a 2x2 preview of their first icons.
- The home layout (tile order and folders) is persisted in io.cozy.home.settings.


<img width="1005" height="448" alt="Capture d’écran 2026-06-21 à 08 27 30" src="https://github.com/user-attachments/assets/44f982e8-ad1e-4119-ae03-bdad6a55dbb6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added home folder support in Applications & Services, including folder tiles with previews, an editable folder dialog (rename/dissolve/remove), and typed tile rendering.
  * Introduced folder-aware drag-and-drop with sortable grid tiles, hold-to-group into folders, in-folder reordering, and a drag overlay preview; includes new layout building and DnD behavior helpers.
  * Added updated UI styling and new folder translations.
* **Bug Fixes**
  * Improved folder rename persistence when closing the dialog.
* **Tests**
  * Added/expanded Jest coverage for the folder dialog, home layout/grid behavior, and folder operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->