### PR TITLE
feat: Display all entrypoints

### DIFF
--- a/src/components/Applications.jsx
+++ b/src/components/Applications.jsx
@@ -17,11 +17,7 @@ import homeConfig from '@/config/home.json'
 import { appsConn } from '@/queries'
 
 const {
-  applications: {
-    sortApplicationsList,
-    selectEntrypoints,
-    checkEntrypointCondition
-  }
+  applications: { sortApplicationsList, checkEntrypointCondition }
 } = models
 
 const LoadingAppTiles = memo(({ num }) => {
@@ -76,39 +72,28 @@ const getApplicationsList = data => {
   }
 }
 
-// We get only the entrypoints we want:
-// - Drive onlyoffice
 const getEntrypoints = apps => {
-  const driveApp = apps.find(app => app.slug === 'drive') || {}
+  return (apps || []).flatMap(app =>
+    (app.entrypoints || [])
+      .filter(entrypoint => {
+        const conditions = entrypoint.conditions || []
 
-  const driveEntrypoints = driveApp.entrypoints || []
+        return conditions.every(condition => {
+          if (
+            condition.type === 'flag' &&
+            condition.name === 'bar.onlyoffice.enabled'
+          ) {
+            return true
+          }
 
-  const selectedEntrypoints = selectEntrypoints(driveEntrypoints, [
-    'new-file-type-text',
-    'new-file-type-sheet',
-    'new-file-type-slide'
-  ])
-
-  // Custom filtering because we want to ignore flag related to top bar
-  const filteredEntrypoints = selectedEntrypoints.filter(entrypoint => {
-    const conditions = entrypoint.conditions || []
-
-    return conditions.every(condition => {
-      if (
-        condition.type === 'flag' &&
-        condition.name === 'bar.onlyoffice.enabled'
-      ) {
-        return true
-      }
-
-      return checkEntrypointCondition(condition)
-    })
-  })
-
-  return filteredEntrypoints.map(entrypoint => ({
-    ...entrypoint,
-    slug: driveApp.slug
-  }))
+          return checkEntrypointCondition(condition)
+        })
+      })
+      .map(entrypoint => ({
+        ...entrypoint,
+        slug: app.slug
+      }))
+  )
 }
 
 export const useApps = () => {


### PR DESCRIPTION
No idea why I restricted previously entrypoints to a set of drive entrypoint because:
- currently we have only entrypoints in drive
- it removes the purpose of entrypoints if we need to update an app when we add an entrypoint

If one day we want to have entrypoint for only some part of the code, we need to extend the conditions attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how app entrypoints are gathered and filtered, so more app actions can appear correctly across the product.
  * Entry points now retain their source app information, helping ensure the right options are shown in the right place.
  * Updated condition handling so the `bar.onlyoffice.enabled` setting is consistently respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->