### PR TITLE
fix(home): retry initial data queries on transient fetch failures

### DIFF
--- a/src/hooks/useFetchInitialData.jsx
+++ b/src/hooks/useFetchInitialData.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react'
 
-import { useQuery } from 'cozy-client'
 import log from 'cozy-logger'
 
+import { useQueryWithRetry } from '@/hooks/useQueryWithRetry'
 import {
   makeAccountsQuery,
   makeAppsQuery,
@@ -11,16 +11,19 @@ import {
 } from '@/queries'
 
 export const useFetchInitialData = () => {
-  const accountsQuery = useQuery(
+  const accountsQuery = useQueryWithRetry(
     makeAccountsQuery.definition,
     makeAccountsQuery.options
   )
-  const konnectorsQuery = useQuery(
+  const konnectorsQuery = useQueryWithRetry(
     makeKonnectorsQuery.definition,
     makeKonnectorsQuery.options
   )
-  const appsQuery = useQuery(makeAppsQuery.definition, makeAppsQuery.options)
-  const triggersQuery = useQuery(
+  const appsQuery = useQueryWithRetry(
+    makeAppsQuery.definition,
+    makeAppsQuery.options
+  )
+  const triggersQuery = useQueryWithRetry(
     makeTriggersQuery.definition,
     makeTriggersQuery.options
   )
@@ -46,9 +49,15 @@ export const useFetchInitialData = () => {
   }, [allQueries])
 
   const isFetching = allQueries.some(
-    query => query.fetchStatus === 'loading' || query.fetchStatus === 'pending'
+    query =>
+      query.fetchStatus === 'loading' ||
+      query.fetchStatus === 'pending' ||
+      query.isRetrying
   )
-  const hasError = allQueries.some(query => query.fetchStatus === 'failed')
+  // A query is only considered in error once useQueryWithRetry has exhausted its
+  // retries: a transient network failure keeps the app in the loading state
+  // instead of flashing the initial-data error screen.
+  const hasError = allQueries.some(query => query.hasError)
 
   return {
     isFetching,

--- a/src/hooks/useFetchInitialData.spec.jsx
+++ b/src/hooks/useFetchInitialData.spec.jsx
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react'
+
+import { useFetchInitialData } from './useFetchInitialData'
+import { useQueryWithRetry } from './useQueryWithRetry'
+
+jest.mock('./useQueryWithRetry')
+jest.mock('cozy-logger', () => ({ __esModule: true, default: jest.fn() }))
+
+const loadedQuery = {
+  fetchStatus: 'loaded',
+  data: [],
+  isRetrying: false,
+  hasError: false
+}
+
+describe('useFetchInitialData', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not report an error while a query is still retrying', () => {
+    useQueryWithRetry
+      .mockReturnValueOnce({
+        fetchStatus: 'failed',
+        data: undefined,
+        isRetrying: true,
+        hasError: false
+      })
+      .mockReturnValue(loadedQuery)
+
+    const { result } = renderHook(() => useFetchInitialData())
+
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.isFetching).toBe(true)
+  })
+
+  it('reports an error once a query has exhausted its retries', () => {
+    useQueryWithRetry
+      .mockReturnValueOnce({
+        fetchStatus: 'failed',
+        data: undefined,
+        isRetrying: false,
+        hasError: true
+      })
+      .mockReturnValue(loadedQuery)
+
+    const { result } = renderHook(() => useFetchInitialData())
+
+    expect(result.current.hasError).toBe(true)
+  })
+})

--- a/src/hooks/useQueryWithRetry.jsx
+++ b/src/hooks/useQueryWithRetry.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+
+import { useQuery } from 'cozy-client'
+
+export const MAX_RETRIES = 3
+const RETRY_BASE_DELAY = 500
+
+// NOTE: this is a stopgap. Automatically retrying transient fetch failures
+// (e.g. "Failed to fetch" / NetworkError when the stack momentarily cannot be
+// reached) should be a first-class cozy-client capability, a retry option on
+// useQuery or a dedicated RetryLink, rather than being re-implemented in every
+// app. See linagora/cozy-client#1694 (related: linagora/cozy-client#1031).
+//
+// Wraps useQuery and, when a query ends up in `failed` (a thrown fetch, not an
+// HTTP error status), retries it a few times with exponential backoff before
+// surfacing the failure. While retries remain the consumer sees `isRetrying`
+// (keep showing a spinner) rather than `hasError`.
+export const useQueryWithRetry = (definition, options) => {
+  const queryResult = useQuery(definition, options)
+  const { fetchStatus, fetch } = queryResult
+  const [retryCount, setRetryCount] = useState(0)
+  const [prevFetchStatus, setPrevFetchStatus] = useState(fetchStatus)
+
+  // Reset the retry budget after a success. This is a derived-state adjustment
+  // done during render (not in an effect), so a later transient failure gets
+  // its own retries.
+  if (fetchStatus !== prevFetchStatus) {
+    setPrevFetchStatus(fetchStatus)
+    if (fetchStatus === 'loaded' && retryCount !== 0) {
+      setRetryCount(0)
+    }
+  }
+
+  useEffect(() => {
+    if (fetchStatus !== 'failed' || retryCount >= MAX_RETRIES) return
+
+    const delay = RETRY_BASE_DELAY * 2 ** retryCount
+    const timeoutId = setTimeout(() => {
+      fetch()
+      setRetryCount(count => count + 1)
+    }, delay)
+
+    return () => clearTimeout(timeoutId)
+  }, [fetchStatus, retryCount, fetch])
+
+  return {
+    ...queryResult,
+    isRetrying: fetchStatus === 'failed' && retryCount < MAX_RETRIES,
+    hasError: fetchStatus === 'failed' && retryCount >= MAX_RETRIES
+  }
+}

--- a/src/hooks/useQueryWithRetry.spec.jsx
+++ b/src/hooks/useQueryWithRetry.spec.jsx
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useQuery } from 'cozy-client'
+
+import { useQueryWithRetry } from './useQueryWithRetry'
+
+jest.mock('cozy-client')
+
+const definition = jest.fn()
+const options = { as: 'io.cozy.test' }
+
+describe('useQueryWithRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  it('retries a failed query by calling fetch() after a backoff delay', () => {
+    const fetch = jest.fn()
+    useQuery.mockReturnValue({ fetchStatus: 'failed', data: undefined, fetch })
+
+    renderHook(() => useQueryWithRetry(definition, options))
+
+    expect(fetch).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces hasError only once the retries are exhausted', () => {
+    const fetch = jest.fn()
+    useQuery.mockReturnValue({ fetchStatus: 'failed', data: undefined, fetch })
+
+    const { result } = renderHook(() => useQueryWithRetry(definition, options))
+
+    // While retries remain, the failure is not surfaced as an error
+    expect(result.current.isRetrying).toBe(true)
+    expect(result.current.hasError).toBe(false)
+
+    // Exhaust the retries (exponential backoff: 500 → 1000 → 2000)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(result.current.isRetrying).toBe(false)
+    expect(result.current.hasError).toBe(true)
+
+    // No further retries are scheduled once exhausted
+    act(() => {
+      jest.advanceTimersByTime(10000)
+    })
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('resets its retry budget after a successful load', () => {
+    const fetch = jest.fn()
+    useQuery.mockReturnValue({ fetchStatus: 'failed', data: undefined, fetch })
+
+    const { result, rerender } = renderHook(() =>
+      useQueryWithRetry(definition, options)
+    )
+
+    // Exhaust the retries
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+    act(() => {
+      jest.advanceTimersByTime(2000)
+    })
+    expect(result.current.hasError).toBe(true)
+
+    // The query recovers
+    useQuery.mockReturnValue({ fetchStatus: 'loaded', data: [], fetch })
+    act(() => {
+      rerender()
+    })
+    expect(result.current.hasError).toBe(false)
+
+    // A later transient failure gets its own fresh retry budget
+    useQuery.mockReturnValue({ fetchStatus: 'failed', data: undefined, fetch })
+    act(() => {
+      rerender()
+    })
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.isRetrying).toBe(true)
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+    expect(fetch).toHaveBeenCalledTimes(4)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a `useQueryWithRetry` hook that retries a `failed` query with exponential backoff, exposing an `isRetrying` state and only reporting `hasError` once retries are exhausted.
- Wire `useFetchInitialData` to it, so a transient network failure (a thrown fetch such as "Failed to fetch" / NetworkError) keeps the home in its loading state and no longer flips straight to the `error.initial` screen.
- Retrying transient failures should ultimately be a cozy-client capability: linagora/cozy-client#1694.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry behavior for initial data loading, helping the app recover from temporary network issues.
  * The loading state now stays active while retries are in progress, reducing premature error screens.

* **Bug Fixes**
  * Improved error handling so errors are shown only after retries are exhausted.
  * Refreshed loading/error state behavior across key data queries for a smoother startup experience.

* **Tests**
  * Added coverage for retry timing, retry exhaustion, and recovery after successful loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->