### PR TITLE
feat: declare the io.cozy.banners permission

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -15,6 +15,11 @@
   "licence": "AGPL-3.0",
   "offline_support": true,
   "permissions": {
+    "banners": {
+      "description": "Required by the cozy-bar to display platform messages",
+      "type": "io.cozy.banners",
+      "verbs": ["GET", "PUT"]
+    },
     "home": {
       "description": "Required to manage default redirection update",
       "type": "io.cozy.home.settings",


### PR DESCRIPTION
## Context

The bar renders platform messages inside the application. It reads them from the application's own context, so without the doctype declared the read is refused and nothing is displayed.

## Solution

Declare `io.cozy.banners`. `GET` to read, `PUT` because dismissing a banner writes `dismissedAt`, the only field a client ever writes.

No application code changes: the bar renders them.

Closes #1588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and updating banner content through the app’s permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->